### PR TITLE
Implement starter UI with mock model

### DIFF
--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		95CB3F7127D8E79C0086E9E3 /* TripCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6727D8E79A0086E9E3 /* TripCardView.swift */; };
+		95CB3F7227D8E79C0086E9E3 /* MockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6827D8E79A0086E9E3 /* MockModel.swift */; };
+		95CB3F7327D8E79C0086E9E3 /* ItineraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6927D8E79A0086E9E3 /* ItineraryView.swift */; };
+		95CB3F7427D8E79C0086E9E3 /* PlanHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6A27D8E79B0086E9E3 /* PlanHeaderView.swift */; };
+		95CB3F7527D8E79C0086E9E3 /* PlanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6B27D8E79B0086E9E3 /* PlanView.swift */; };
+		95CB3F7627D8E79C0086E9E3 /* PlanCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6C27D8E79B0086E9E3 /* PlanCardView.swift */; };
+		95CB3F7727D8E79C0086E9E3 /* PlansListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6D27D8E79B0086E9E3 /* PlansListView.swift */; };
+		95CB3F7827D8E79C0086E9E3 /* PackingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6E27D8E79B0086E9E3 /* PackingListView.swift */; };
+		95CB3F7927D8E79C0086E9E3 /* TripsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F6F27D8E79C0086E9E3 /* TripsView.swift */; };
+		95CB3F7A27D8E79C0086E9E3 /* TripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CB3F7027D8E79C0086E9E3 /* TripView.swift */; };
 		B99D964927D73503009B66AE /* TourMateApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D964827D73503009B66AE /* TourMateApp.swift */; };
 		B99D964B27D73503009B66AE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99D964A27D73503009B66AE /* ContentView.swift */; };
 		B99D964D27D73507009B66AE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B99D964C27D73507009B66AE /* Assets.xcassets */; };
@@ -34,6 +44,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		95CB3F6727D8E79A0086E9E3 /* TripCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripCardView.swift; sourceTree = "<group>"; };
+		95CB3F6827D8E79A0086E9E3 /* MockModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockModel.swift; sourceTree = "<group>"; };
+		95CB3F6927D8E79A0086E9E3 /* ItineraryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItineraryView.swift; sourceTree = "<group>"; };
+		95CB3F6A27D8E79B0086E9E3 /* PlanHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanHeaderView.swift; sourceTree = "<group>"; };
+		95CB3F6B27D8E79B0086E9E3 /* PlanView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanView.swift; sourceTree = "<group>"; };
+		95CB3F6C27D8E79B0086E9E3 /* PlanCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanCardView.swift; sourceTree = "<group>"; };
+		95CB3F6D27D8E79B0086E9E3 /* PlansListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlansListView.swift; sourceTree = "<group>"; };
+		95CB3F6E27D8E79B0086E9E3 /* PackingListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PackingListView.swift; sourceTree = "<group>"; };
+		95CB3F6F27D8E79C0086E9E3 /* TripsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripsView.swift; sourceTree = "<group>"; };
+		95CB3F7027D8E79C0086E9E3 /* TripView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripView.swift; sourceTree = "<group>"; };
 		B99D964527D73503009B66AE /* TourMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TourMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B99D964827D73503009B66AE /* TourMateApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TourMateApp.swift; sourceTree = "<group>"; };
 		B99D964A27D73503009B66AE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -96,6 +116,16 @@
 			children = (
 				B99D964827D73503009B66AE /* TourMateApp.swift */,
 				B99D964A27D73503009B66AE /* ContentView.swift */,
+				95CB3F6827D8E79A0086E9E3 /* MockModel.swift */,
+				95CB3F6F27D8E79C0086E9E3 /* TripsView.swift */,
+				95CB3F6727D8E79A0086E9E3 /* TripCardView.swift */,
+				95CB3F7027D8E79C0086E9E3 /* TripView.swift */,
+				95CB3F6927D8E79A0086E9E3 /* ItineraryView.swift */,
+				95CB3F6D27D8E79B0086E9E3 /* PlansListView.swift */,
+				95CB3F6A27D8E79B0086E9E3 /* PlanHeaderView.swift */,
+				95CB3F6C27D8E79B0086E9E3 /* PlanCardView.swift */,
+				95CB3F6B27D8E79B0086E9E3 /* PlanView.swift */,
+				95CB3F6E27D8E79B0086E9E3 /* PackingListView.swift */,
 				B99D964C27D73507009B66AE /* Assets.xcassets */,
 				B99D964E27D73507009B66AE /* Preview Content */,
 			);
@@ -279,7 +309,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				B99D964B27D73503009B66AE /* ContentView.swift in Sources */,
+				95CB3F7227D8E79C0086E9E3 /* MockModel.swift in Sources */,
+				95CB3F7827D8E79C0086E9E3 /* PackingListView.swift in Sources */,
+				95CB3F7A27D8E79C0086E9E3 /* TripView.swift in Sources */,
+				95CB3F7427D8E79C0086E9E3 /* PlanHeaderView.swift in Sources */,
 				B99D964927D73503009B66AE /* TourMateApp.swift in Sources */,
+				95CB3F7727D8E79C0086E9E3 /* PlansListView.swift in Sources */,
+				95CB3F7327D8E79C0086E9E3 /* ItineraryView.swift in Sources */,
+				95CB3F7627D8E79C0086E9E3 /* PlanCardView.swift in Sources */,
+				95CB3F7527D8E79C0086E9E3 /* PlanView.swift in Sources */,
+				95CB3F7927D8E79C0086E9E3 /* TripsView.swift in Sources */,
+				95CB3F7127D8E79C0086E9E3 /* TripCardView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -440,6 +480,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TourMate/Preview Content\"";
+				DEVELOPMENT_TEAM = JH4N7Z4FH9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -468,6 +509,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TourMate/Preview Content\"";
+				DEVELOPMENT_TEAM = JH4N7Z4FH9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/TourMate/TourMate/ContentView.swift
+++ b/TourMate/TourMate/ContentView.swift
@@ -9,13 +9,12 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        TripsView()
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView().environmentObject(MockModel())
     }
 }

--- a/TourMate/TourMate/ItineraryView.swift
+++ b/TourMate/TourMate/ItineraryView.swift
@@ -1,0 +1,62 @@
+//
+//  ItineraryView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 8/3/22.
+//
+
+import SwiftUI
+
+struct ItineraryView: View {
+    @EnvironmentObject var model: MockModel
+    @State var id: Int
+
+    var dateString: String {
+        let trip = model.trips[id]
+        let sortedPlans = trip.plans.sorted { (plan1, plan2) in
+            plan1.startDate < plan2.startDate
+        }
+        var startDateString = "Unknown"
+        var endDateString = "Unknown"
+        if let firstPlan = sortedPlans.first, let lastPlan = sortedPlans.last {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .full
+            dateFormatter.timeZone = firstPlan.timeZone
+            startDateString = dateFormatter.string(from: firstPlan.startDate)
+            dateFormatter.timeZone = lastPlan.timeZone
+            endDateString = dateFormatter.string(from: lastPlan.endDate ?? lastPlan.startDate)
+        }
+        return startDateString + " - " + endDateString
+    }
+
+    var body: some View {
+        let trip = model.trips[id]
+
+        return ScrollView {
+            LazyVStack {
+                Text(dateString)
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding([.bottom, .horizontal])
+
+                AsyncImage(url: URL(string: trip.imageUrl)) { image in
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(height: 200, alignment: .center)
+                        .clipped()
+                } placeholder: {
+                    Color.gray
+                }
+
+                PlansListView(id: id)
+            }
+        }
+    }
+}
+
+struct ItineraryView_Previews: PreviewProvider {
+    static var previews: some View {
+        ItineraryView(id: 0).environmentObject(MockModel())
+    }
+}

--- a/TourMate/TourMate/MockModel.swift
+++ b/TourMate/TourMate/MockModel.swift
@@ -1,0 +1,62 @@
+//
+//  MockModel.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 7/3/22.
+//
+
+import Foundation
+
+struct Trip {
+    var id: Int
+    var name: String
+    var imageUrl: String
+    var plans: [Plan]
+}
+
+struct Plan {
+    var id: Int
+    var name: String
+    var startDate: Date
+    var endDate: Date?
+    var timeZone: TimeZone
+    var imageUrl: String
+}
+
+final class MockModel: ObservableObject {
+    @Published var trips: [Trip]
+
+    init() {
+        let plans: [Plan] = [
+            Plan(id: 0,
+                 name: "Visit Venice Beach",
+                 startDate: Date(timeIntervalSince1970: 1651442400),
+                 endDate: Date(timeIntervalSince1970: 1651453200),
+                 timeZone: TimeZone(abbreviation: "PST")!,
+                 imageUrl: "https://source.unsplash.com/qxstzQ__HMk"),
+            Plan(id: 1,
+                 name: "Dinner at Spago",
+                 startDate: Date(timeIntervalSince1970: 1651460400),
+                 endDate: Date(timeIntervalSince1970: 1651467600),
+                 timeZone: TimeZone(abbreviation: "PST")!,
+                 imageUrl: "https://source.unsplash.com/pT0qBgNa0VU"),
+            Plan(id: 2,
+                 name: "Visit Grand Canyon",
+                 startDate: Date(timeIntervalSince1970: 1651475400),
+                 timeZone: TimeZone(abbreviation: "MST")!,
+                 imageUrl: "https://source.unsplash.com/pT0qBgNa0VU")
+        ]
+
+        self.trips = [
+            Trip(id: 0,
+                 name: "West Coast Summer",
+                 imageUrl: "https://source.unsplash.com/qxstzQ__HMk",
+                 plans: plans),
+            Trip(id: 1,
+                 name: "Winter in Japan",
+                 imageUrl: "https://source.unsplash.com/pT0qBgNa0VU",
+                 plans: plans)
+        ]
+    }
+
+}

--- a/TourMate/TourMate/PackingListView.swift
+++ b/TourMate/TourMate/PackingListView.swift
@@ -1,0 +1,20 @@
+//
+//  PackingListView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 8/3/22.
+//
+
+import SwiftUI
+
+struct PackingListView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct PackingListView_Previews: PreviewProvider {
+    static var previews: some View {
+        PackingListView()
+    }
+}

--- a/TourMate/TourMate/PlanCardView.swift
+++ b/TourMate/TourMate/PlanCardView.swift
@@ -1,0 +1,65 @@
+//
+//  PlanCardView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 8/3/22.
+//
+
+import SwiftUI
+
+struct PlanCardView: View {
+    let title: String
+    let startDate: Date
+    let endDate: Date?
+    let dateFormatter: DateFormatter
+
+    init(title: String, startDate: Date, endDate: Date? = nil, timeZone: TimeZone) {
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.dateFormatter = DateFormatter()
+        self.dateFormatter.timeStyle = .short
+        self.dateFormatter.timeZone = timeZone
+    }
+
+    var startTimeString: String {
+        dateFormatter.string(from: startDate)
+    }
+
+    var endTimeString: String? {
+        guard let endDate = endDate else {
+            return nil
+        }
+        return dateFormatter.string(from: endDate)
+    }
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                HStack(spacing: 0) {
+                    Text(startTimeString)
+                        .font(.caption)
+                    if let endTimeString = endTimeString {
+                        Text(" - " + endTimeString)
+                            .font(.caption)
+                    }
+                }
+                Text(title)
+                    .font(.headline)
+            }
+            .padding()
+            Spacer()
+        }
+        .background(RoundedRectangle(cornerRadius: 16)
+                        .fill(Color.primary.opacity(0.1)))
+    }
+}
+
+struct PlanCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanCardView(title: "Visit Venice Beach",
+                     startDate: Date(timeIntervalSince1970: 1651442400),
+                     endDate: Date(timeIntervalSince1970: 1651453200),
+                     timeZone: TimeZone(abbreviation: "PST")!)
+    }
+}

--- a/TourMate/TourMate/PlanHeaderView.swift
+++ b/TourMate/TourMate/PlanHeaderView.swift
@@ -1,0 +1,37 @@
+//
+//  PlanHeaderView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 9/3/22.
+//
+
+import SwiftUI
+
+struct PlanHeaderView: View {
+    let date: Date
+    let dateFormatter: DateFormatter
+
+    init(date: Date, timeZone: TimeZone) {
+        self.date = date
+        self.dateFormatter = DateFormatter()
+        // self.dateFormatter.setLocalizedDateFormatFromTemplate("EEE d MMM yyyy")
+        self.dateFormatter.dateStyle = .full
+        self.dateFormatter.timeZone = timeZone
+    }
+
+    var dateString: String {
+        dateFormatter.string(from: date)
+    }
+
+    var body: some View {
+        Text(dateString)
+            .font(.subheadline)
+    }
+}
+
+struct PlanHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanHeaderView(date: Date(timeIntervalSince1970: 1651442400),
+                       timeZone: TimeZone(abbreviation: "PST")!)
+    }
+}

--- a/TourMate/TourMate/PlanView.swift
+++ b/TourMate/TourMate/PlanView.swift
@@ -1,0 +1,73 @@
+//
+//  PlanView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 8/3/22.
+//
+
+import SwiftUI
+
+struct PlanView: View {
+    let title: String
+    let startDate: Date
+    let endDate: Date?
+    let dateFormatter: DateFormatter
+
+    init(title: String, startDate: Date, endDate: Date? = nil, timeZone: TimeZone) {
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.dateFormatter = DateFormatter()
+        self.dateFormatter.dateStyle = .full
+        self.dateFormatter.timeStyle = .full
+        self.dateFormatter.timeZone = timeZone
+    }
+
+    var startTimeString: String {
+        dateFormatter.string(from: startDate)
+    }
+
+    var endTimeString: String? {
+        guard let endDate = endDate else {
+            return nil
+        }
+        return dateFormatter.string(from: endDate)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("From")
+                        .font(.caption)
+                    Text(startTimeString)
+                        .font(.headline)
+                }
+                Spacer()
+            }
+            if let endTimeString = endTimeString {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("To")
+                            .font(.caption)
+                        Text(endTimeString)
+                            .font(.headline)
+                    }
+                    Spacer()
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .navigationTitle(title)
+    }
+}
+
+struct PlanView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanView(title: "Visit Venice Beach",
+                 startDate: Date(timeIntervalSince1970: 1651442400),
+                 endDate: Date(timeIntervalSince1970: 1651453200),
+                 timeZone: TimeZone(abbreviation: "PST")!)
+    }
+}

--- a/TourMate/TourMate/PlansListView.swift
+++ b/TourMate/TourMate/PlansListView.swift
@@ -1,0 +1,65 @@
+//
+//  PlansListView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 8/3/22.
+//
+
+import SwiftUI
+
+struct PlansListView: View {
+    @EnvironmentObject var model: MockModel
+    @State var id: Int
+
+    typealias Day = (date: Date, plans: [Plan])
+    var days: [Day] {
+        let sortedPlans = model.trips[id].plans.sorted { (plan1, plan2) in
+            plan1.startDate < plan2.startDate
+        }
+        let plansByDay: [Date: [Plan]] = sortedPlans.reduce(into: [:]) { acc, cur in
+            let components = Calendar.current.dateComponents(in: cur.timeZone, from: cur.startDate)
+            let dateComponents = DateComponents(year: components.year,
+                                                month: components.month,
+                                                day: components.day)
+            let date = Calendar.current.date(from: dateComponents)!
+            let existing = acc[date] ?? []
+            acc[date] = existing + [cur]
+        }
+        return plansByDay.sorted(by: { $0.key < $1.key }).map { day in
+            (date: day.key, plans: day.value)
+        }
+    }
+
+    var body: some View {
+
+        return LazyVStack {
+            ForEach(days, id: \.date) { day in
+                VStack(alignment: .leading) {
+                    PlanHeaderView(date: day.date, timeZone: Calendar.current.timeZone)
+
+                    ForEach(day.plans, id: \.id) { plan in
+                        NavigationLink {
+                            PlanView(title: plan.name,
+                                     startDate: plan.startDate,
+                                     endDate: plan.endDate,
+                                     timeZone: plan.timeZone)
+                        } label: {
+                            PlanCardView(title: plan.name,
+                                         startDate: plan.startDate,
+                                         endDate: plan.endDate,
+                                         timeZone: plan.timeZone)
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}
+
+struct PlansListView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlansListView(id: 0).environmentObject(MockModel())
+    }
+}

--- a/TourMate/TourMate/TourMateApp.swift
+++ b/TourMate/TourMate/TourMateApp.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 @main
 struct TourMateApp: App {
+    @StateObject private var model = MockModel()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(model)
         }
     }
 }

--- a/TourMate/TourMate/TripCardView.swift
+++ b/TourMate/TourMate/TripCardView.swift
@@ -1,0 +1,56 @@
+//
+//  TripCardView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 7/3/22.
+//
+
+import SwiftUI
+
+struct TripCardView: View {
+    let title: String
+    let subtitle: String
+    let imageUrl: String
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            AsyncImage(url: URL(string: imageUrl)) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(height: 200, alignment: .center)
+                    .clipped()
+            } placeholder: {
+                Color.gray
+            }
+
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(title)
+                        .font(.headline)
+                    Text(subtitle)
+                        .font(.subheadline)
+                }
+                Spacer()
+            }
+            .padding()
+            .foregroundColor(.primary)
+            .background(Color.primary
+                            .colorInvert()
+                            .opacity(0.75))
+        }
+        .clipShape(
+            RoundedRectangle(cornerRadius: 16)
+        )
+        .padding([.horizontal])
+    }
+}
+
+struct TripCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        let view = TripCardView(title: "West Coast Summer",
+                                subtitle: "Sun, 1 May - Sat, 30 May",
+                                imageUrl: "https://source.unsplash.com/qxstzQ__HMk")
+        ForEach(ColorScheme.allCases, id: \.self, content: view.preferredColorScheme)
+    }
+}

--- a/TourMate/TourMate/TripView.swift
+++ b/TourMate/TourMate/TripView.swift
@@ -1,0 +1,37 @@
+//
+//  TripDetailView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 7/3/22.
+//
+
+import SwiftUI
+
+struct TripView: View {
+    @EnvironmentObject var model: MockModel
+    @State var id: Int
+
+    var body: some View {
+        let trip = model.trips[id]
+
+        return TabView {
+            ItineraryView(id: id)
+                .tabItem {
+                    Image(systemName: "menucard.fill")
+                    Text("Itinerary")
+                }
+            PackingListView()
+                .tabItem {
+                    Image(systemName: "list.bullet.rectangle.portrait.fill")
+                    Text("Packing List")
+                }
+        }
+        .navigationTitle(trip.name)
+    }
+}
+
+struct TripView_Previews: PreviewProvider {
+    static var previews: some View {
+        TripView(id: 0).environmentObject(MockModel())
+    }
+}

--- a/TourMate/TourMate/TripsView.swift
+++ b/TourMate/TourMate/TripsView.swift
@@ -1,0 +1,65 @@
+//
+//  TripsView.swift
+//  Tourmate
+//
+//  Created by Rayner Lim on 7/3/22.
+//
+
+import SwiftUI
+
+struct TripsView: View {
+    @EnvironmentObject var model: MockModel
+
+    func getDateString(id: Int) -> String {
+        let trip = model.trips[id]
+        let sortedPlans = trip.plans.sorted { (plan1, plan2) in
+            plan1.startDate < plan2.startDate
+        }
+        var startDateString = "Unknown"
+        var endDateString = "Unknown"
+        if let firstPlan = sortedPlans.first, let lastPlan = sortedPlans.last {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .full
+            dateFormatter.timeZone = firstPlan.timeZone
+            startDateString = dateFormatter.string(from: firstPlan.startDate)
+            dateFormatter.timeZone = lastPlan.timeZone
+            endDateString = dateFormatter.string(from: lastPlan.endDate ?? lastPlan.startDate)
+        }
+        return startDateString + " - " + endDateString
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LazyVStack {
+                    ForEach(model.trips, id: \.id) { trip in
+                        NavigationLink {
+                            TripView(id: trip.id)
+                        } label: {
+                            TripCardView(title: trip.name,
+                                         subtitle: getDateString(id: trip.id),
+                                         imageUrl: trip.imageUrl)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Trips")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        print("Add trip unimplemented")
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+struct TripsView_Previews: PreviewProvider {
+    static var previews: some View {
+        TripsView().environmentObject(MockModel())
+    }
+}


### PR DESCRIPTION
Implement starter UI with mock model

TripsView |  TripView | PlanView
:-:|:-:|:-:
<img src="https://user-images.githubusercontent.com/29230362/157461318-f5dd0fbc-ef13-4071-b66c-ea3069d0eb85.png" height="480">  |  <img src="https://user-images.githubusercontent.com/29230362/157461331-f16581db-a7c9-405b-9906-4daf7d9a6e77.png" height="480"> | <img src="https://user-images.githubusercontent.com/29230362/157462156-4428a247-2e42-49b8-af1c-8099622dcd6e.png" height="480">

View hierarchy (**bold** for page, _italic_ for tab):
- TourMateApp
  - ContentView
    - **TripsView**
      - TripCardView
      - **TripView**
        - _ItineraryView_
          - PlansListView
            - PlanHeaderView
            - PlanCardView     
            - **PlanView**
        - _PackingListView_