### PR TITLE
Remove super on encoding and decoding of plans

### DIFF
--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		4CCBBD1B27DE651F00F9C250 /* FirebasePlanController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCBBD1A27DE651F00F9C250 /* FirebasePlanController.swift */; };
 		4CCBBD1F27DE67B400F9C250 /* PlanStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCBBD1E27DE67B400F9C250 /* PlanStatus.swift */; };
 		4CCBBD2327DE687B00F9C250 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCBBD2227DE687A00F9C250 /* Comment.swift */; };
+		4CE02B8B27EAE93900480D73 /* TripAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE02B8A27EAE93900480D73 /* TripAdapter.swift */; };
+		4CE02B8D27EAE9CD00480D73 /* UserAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE02B8C27EAE9CD00480D73 /* UserAdapter.swift */; };
 		953570E727E5BFBF000DF0C2 /* TripsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953570E627E5BFBF000DF0C2 /* TripsView.swift */; };
 		953570E927E5BFC7000DF0C2 /* TripCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953570E827E5BFC7000DF0C2 /* TripCard.swift */; };
 		953570EB27E5BFD1000DF0C2 /* AddTripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953570EA27E5BFD1000DF0C2 /* AddTripView.swift */; };
@@ -151,6 +153,8 @@
 		4CCBBD1A27DE651F00F9C250 /* FirebasePlanController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebasePlanController.swift; sourceTree = "<group>"; };
 		4CCBBD1E27DE67B400F9C250 /* PlanStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanStatus.swift; sourceTree = "<group>"; };
 		4CCBBD2227DE687A00F9C250 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
+		4CE02B8A27EAE93900480D73 /* TripAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripAdapter.swift; sourceTree = "<group>"; };
+		4CE02B8C27EAE9CD00480D73 /* UserAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAdapter.swift; sourceTree = "<group>"; };
 		720CE2DA18816A7C56653A32 /* Pods_TourMate.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TourMate.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F0AD6F3D818D6A89B4B41BF /* Pods-TourMate-TourMateUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TourMate-TourMateUITests.release.xcconfig"; path = "Target Support Files/Pods-TourMate-TourMateUITests/Pods-TourMate-TourMateUITests.release.xcconfig"; sourceTree = "<group>"; };
 		953570E627E5BFBF000DF0C2 /* TripsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripsView.swift; sourceTree = "<group>"; };
@@ -618,6 +622,8 @@
 			isa = PBXGroup;
 			children = (
 				4C3BB2E827E60DD10022C3C1 /* PlanAdapter.swift */,
+				4CE02B8A27EAE93900480D73 /* TripAdapter.swift */,
+				4CE02B8C27EAE9CD00480D73 /* UserAdapter.swift */,
 			);
 			path = Adapters;
 			sourceTree = "<group>";
@@ -1048,6 +1054,7 @@
 				4CB954EC27DE3F08001410AD /* FirebaseAdaptedType.swift in Sources */,
 				4CCBBD1F27DE67B400F9C250 /* PlanStatus.swift in Sources */,
 				B99D964B27D73503009B66AE /* ContentView.swift in Sources */,
+				4CE02B8B27EAE93900480D73 /* TripAdapter.swift in Sources */,
 				004981AB27E2FF3C007BDB2E /* SettingsView.swift in Sources */,
 				4CB954D227DDE039001410AD /* FirebaseConfig.swift in Sources */,
 				00582F7927E745A3008756E9 /* EditAccommodationView.swift in Sources */,
@@ -1081,6 +1088,7 @@
 				B967C33E27DDE9BD0023B34D /* TransportFormView.swift in Sources */,
 				00582F7527E74590008756E9 /* EditFlightView.swift in Sources */,
 				4C6D1BA127E627A900D34087 /* PlanType.swift in Sources */,
+				4CE02B8D27EAE9CD00480D73 /* UserAdapter.swift in Sources */,
 				95CB3F7727D8E79C0086E9E3 /* PlansListView.swift in Sources */,
 				B967C33527DDCA4E0023B34D /* AddPlanView.swift in Sources */,
 				0092523827DA573500F4F029 /* LaunchView.swift in Sources */,

--- a/TourMate/TourMate/Backend/Persistence/Config/FirebaseConfig.swift
+++ b/TourMate/TourMate/Backend/Persistence/Config/FirebaseConfig.swift
@@ -5,9 +5,15 @@
 //  Created by Keane Chan on 13/3/22.
 //
 
+import Firebase
+
 final class FirebaseConfig {
     static let userCollectionId = "users"
     static let tripCollectionId = "trips"
     static let planCollectionId = "plans"
     static let planDetailsCollectionId = "plandetails"
+
+    static func fieldPath(field: String) -> FieldPath {
+        FieldPath(["base", field])
+    }
 }

--- a/TourMate/TourMate/Backend/Persistence/Managers/FirebasePersistenceManager.swift
+++ b/TourMate/TourMate/Backend/Persistence/Managers/FirebasePersistenceManager.swift
@@ -23,7 +23,7 @@ struct FirebasePersistenceManager: PersistenceManager {
             let any = AnyFirebaseAdaptedData(item)
             try itemRef.setData(from: any)
 
-            print("[FirebasePersistenceManager] Added \(T.self): \(item)")
+            print("[FirebasePersistenceManager] Added or Updated \(T.self): \(id)")
 
             return (true, "")
         } catch {

--- a/TourMate/TourMate/Backend/Persistence/Managers/FirebasePersistenceManager.swift
+++ b/TourMate/TourMate/Backend/Persistence/Managers/FirebasePersistenceManager.swift
@@ -54,7 +54,6 @@ struct FirebasePersistenceManager: PersistenceManager {
     @MainActor
     func fetchItems(field: String, arrayContains id: String) async -> (items: [FirebaseAdaptedData],
                                                                             errorMessage: String) {
-        // Might want to remove the hard coding here in the future
         let query = db.collection(collectionId).whereField(FirebaseConfig.fieldPath(field: field), arrayContains: id)
 
         print("[FirebasePersistenceManager] Fetched Items with Field: \(field), arrayContains: \(id)")

--- a/TourMate/TourMate/Backend/Persistence/Managers/PersistenceManager.swift
+++ b/TourMate/TourMate/Backend/Persistence/Managers/PersistenceManager.swift
@@ -11,7 +11,8 @@ protocol PersistenceManager {
 
     func fetchItem(id: String) async -> (item: FirebaseAdaptedData?, errorMessage: String)
 
-    func fetchItems(field: String, arrayContains id: String) async -> (items: [FirebaseAdaptedData], errorMessage: String)
+    func fetchItems(field: String, arrayContains id: String) async -> (items: [FirebaseAdaptedData],
+                                                                            errorMessage: String)
 
     func fetchItems(field: String, isEqualTo id: String) async -> (items: [FirebaseAdaptedData], errorMessage: String)
 

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedAccommodation.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedAccommodation.swift
@@ -39,8 +39,7 @@ class FirebaseAdaptedAccommodation: FirebaseAdaptedPlan {
         phone = try container.decode(String?.self, forKey: .phone)
         website = try container.decode(String?.self, forKey: .website)
 
-        let superDecoder = try container.superDecoder()
-        try super.init(from: superDecoder)
+        try super.init(from: decoder)
     }
 
     override func encode(to encoder: Encoder) throws {
@@ -50,8 +49,7 @@ class FirebaseAdaptedAccommodation: FirebaseAdaptedPlan {
         try container.encode(phone, forKey: .phone)
         try container.encode(website, forKey: .website)
 
-        let superEncoder = container.superEncoder()
-        try super.encode(to: superEncoder)
+        try super.encode(to: encoder)
     }
 
     override func getType() -> FirebaseAdaptedType {

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedActivity.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedActivity.swift
@@ -43,8 +43,7 @@ class FirebaseAdaptedActivity: FirebaseAdaptedPlan {
         phone = try container.decode(String?.self, forKey: .phone)
         website = try container.decode(String?.self, forKey: .website)
 
-        let superDecoder = try container.superDecoder()
-        try super.init(from: superDecoder)
+        try super.init(from: decoder)
     }
 
     override func encode(to encoder: Encoder) throws {
@@ -55,8 +54,7 @@ class FirebaseAdaptedActivity: FirebaseAdaptedPlan {
         try container.encode(phone, forKey: .phone)
         try container.encode(website, forKey: .website)
 
-        let superEncoder = container.superEncoder()
-        try super.encode(to: superEncoder)
+        try super.encode(to: encoder)
     }
 
     override func getType() -> FirebaseAdaptedType {

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedFlight.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedFlight.swift
@@ -66,8 +66,7 @@ class FirebaseAdaptedFlight: FirebaseAdaptedPlan {
         arrivalTerminal = try container.decode(String?.self, forKey: .arrivalTerminal)
         arrivalGate = try container.decode(String?.self, forKey: .arrivalGate)
 
-        let superDecoder = try container.superDecoder()
-        try super.init(from: superDecoder)
+        try super.init(from: decoder)
     }
 
     override func encode(to encoder: Encoder) throws {
@@ -83,8 +82,7 @@ class FirebaseAdaptedFlight: FirebaseAdaptedPlan {
         try container.encode(arrivalTerminal, forKey: .arrivalTerminal)
         try container.encode(arrivalGate, forKey: .arrivalGate)
 
-        let superEncoder = container.superEncoder()
-        try super.encode(to: superEncoder)
+        try super.encode(to: encoder)
     }
 
     override func getType() -> FirebaseAdaptedType {

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedPlan.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedPlan.swift
@@ -64,6 +64,7 @@ class FirebaseAdaptedPlan: FirebaseAdaptedData {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+
         try container.encode(id, forKey: .id)
         try container.encode(tripId, forKey: .tripId)
         try container.encode(name, forKey: .name)

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedRestaurant.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedRestaurant.swift
@@ -40,8 +40,7 @@ class FirebaseAdaptedRestaurant: FirebaseAdaptedPlan {
         phone = try container.decode(String?.self, forKey: .phone)
         website = try container.decode(String?.self, forKey: .website)
 
-        let superDecoder = try container.superDecoder()
-        try super.init(from: superDecoder)
+        try super.init(from: decoder)
     }
 
     override func encode(to encoder: Encoder) throws {
@@ -51,8 +50,7 @@ class FirebaseAdaptedRestaurant: FirebaseAdaptedPlan {
         try container.encode(phone, forKey: .phone)
         try container.encode(website, forKey: .website)
 
-        let superEncoder = container.superEncoder()
-        try super.encode(to: superEncoder)
+        try super.encode(to: encoder)
     }
 
     override func getType() -> FirebaseAdaptedType {

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedTransport.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedTransport.swift
@@ -53,8 +53,7 @@ class FirebaseAdaptedTransport: FirebaseAdaptedPlan {
         vehicleDescription = try container.decode(String?.self, forKey: .vehicleDescription)
         numberOfPassengers = try container.decode(String?.self, forKey: .numberOfPassengers)
 
-        let superDecoder = try container.superDecoder()
-        try super.init(from: superDecoder)
+        try super.init(from: decoder)
     }
 
     override func encode(to encoder: Encoder) throws {
@@ -67,8 +66,7 @@ class FirebaseAdaptedTransport: FirebaseAdaptedPlan {
         try container.encode(vehicleDescription, forKey: .vehicleDescription)
         try container.encode(numberOfPassengers, forKey: .numberOfPassengers)
 
-        let superEncoder = container.superEncoder()
-        try super.encode(to: superEncoder)
+        try super.encode(to: encoder)
     }
 
     override func getType() -> FirebaseAdaptedType {

--- a/TourMate/TourMate/Frontend/Authentication/Views/LogInView.swift
+++ b/TourMate/TourMate/Frontend/Authentication/Views/LogInView.swift
@@ -16,7 +16,7 @@ struct LogInView: View {
     var body: some View {
         VStack(alignment: .center) {
             AuthenticationButton(onPress: onGoogleLogInButtonPressed,
-                                 title: "Log In Google",
+                                 title: "Log In",
                                  maxWidth: containerSize.width / 5.0,
                                  isDisabled: isDisabled)
         }

--- a/TourMate/TourMate/Frontend/Authentication/Views/LogOutView.swift
+++ b/TourMate/TourMate/Frontend/Authentication/Views/LogOutView.swift
@@ -16,7 +16,7 @@ struct LogOutView: View {
     var body: some View {
         VStack(alignment: .center) {
             AuthenticationButton(onPress: onGoogleLogoutButtonPressed,
-                                 title: "Log Out Google",
+                                 title: "Log Out",
                                  maxWidth: containerSize.width / 5.0,
                                  isDisabled: isDisabled)
         }

--- a/TourMate/TourMate/Frontend/Plan/Controllers/FirebasePlanController.swift
+++ b/TourMate/TourMate/Frontend/Plan/Controllers/FirebasePlanController.swift
@@ -9,10 +9,12 @@ import FirebaseAuth
 
 struct FirebasePlanController: PlanController {
 
-    let firebasePersistenceManager = FirebasePersistenceManager(collectionId: FirebaseConfig.planCollectionId)
+    private let firebasePersistenceManager = FirebasePersistenceManager(collectionId: FirebaseConfig.planCollectionId)
+
+    private let planAdapter = PlanAdapter()
 
     func addPlan(plan: Plan) async -> (Bool, String) {
-        await firebasePersistenceManager.addItem(id: plan.id, item: PlanAdapter.toAdaptedPlan(plan: plan))
+        await firebasePersistenceManager.addItem(id: plan.id, item: planAdapter.toAdaptedPlan(plan: plan))
     }
 
     func fetchPlans(withTripId tripId: String) async -> ([Plan], String) {
@@ -28,7 +30,7 @@ struct FirebasePlanController: PlanController {
              return ([], "Unable to convert FirebaseAdaptedData to FirebaseAdaptedPlan")
         }
 
-        let plans = adaptedPlans.map({ PlanAdapter.toPlan(adaptedPlan: $0) })
+        let plans = adaptedPlans.map({ planAdapter.toPlan(adaptedPlan: $0) })
         return (plans, "")
     }
 
@@ -48,7 +50,7 @@ struct FirebasePlanController: PlanController {
             return (nil, "Unable to convert FirebaseAdaptedData to FirebaseAdaptedPlan")
         }
 
-        let plan = PlanAdapter.toPlan(adaptedPlan: adaptedPlan)
+        let plan = planAdapter.toPlan(adaptedPlan: adaptedPlan)
         return (plan, "")
     }
 
@@ -57,6 +59,6 @@ struct FirebasePlanController: PlanController {
     }
 
     func updatePlan(plan: Plan) async -> (Bool, String) {
-        await firebasePersistenceManager.updateItem(id: plan.id, item: PlanAdapter.toAdaptedPlan(plan: plan))
+        await firebasePersistenceManager.updateItem(id: plan.id, item: planAdapter.toAdaptedPlan(plan: plan))
     }
 }

--- a/TourMate/TourMate/Frontend/User/Controllers/FirebaseUserController.swift
+++ b/TourMate/TourMate/Frontend/User/Controllers/FirebaseUserController.swift
@@ -9,8 +9,10 @@ import Foundation
 import FirebaseAuth
 
 struct FirebaseUserController: UserController {
-    let firebasePersistenceManager = FirebasePersistenceManager(
+    private let firebasePersistenceManager = FirebasePersistenceManager(
         collectionId: FirebaseConfig.userCollectionId)
+
+    private let userAdapter = UserAdapter()
 
     func addUser(_ user: User) async -> (Bool, String) {
         guard let currentUser = Auth.auth().currentUser,
@@ -20,7 +22,7 @@ struct FirebaseUserController: UserController {
             return (false, Constants.messageUserNotLoggedIn)
         }
 
-        let adaptedUser = user.toData()
+        let adaptedUser = userAdapter.toAdaptedUser(user: user)
         return await firebasePersistenceManager.addItem(id: currentUser.uid, item: adaptedUser)
     }
 
@@ -41,19 +43,7 @@ struct FirebaseUserController: UserController {
             preconditionFailure()
         }
 
-        return (adaptedUser.toItem(), errorMessage)
+        return (userAdapter.toUser(adaptedUser: adaptedUser), errorMessage)
     }
 
-}
-
-extension User {
-    fileprivate func toData() -> FirebaseAdaptedUser {
-        FirebaseAdaptedUser(id: id, name: name, email: email, imageUrl: imageUrl)
-    }
-}
-
-extension FirebaseAdaptedUser {
-    fileprivate func toItem() -> User {
-        User(id: id, name: name, email: email, imageUrl: imageUrl)
-    }
 }

--- a/TourMate/TourMate/Shared/Adapters/PlanAdapter.swift
+++ b/TourMate/TourMate/Shared/Adapters/PlanAdapter.swift
@@ -4,8 +4,11 @@
 //
 //  Created by Keane Chan on 19/3/22.
 //
+
 class PlanAdapter {
-    static func toAdaptedPlan(plan: Plan) -> FirebaseAdaptedPlan {
+    init() {}
+
+    func toAdaptedPlan(plan: Plan) -> FirebaseAdaptedPlan {
         guard let planType = FirebaseAdaptedType(rawValue: plan.planType.rawValue) else {
             preconditionFailure()
         }
@@ -27,7 +30,7 @@ class PlanAdapter {
         }
     }
 
-    static func toPlan(adaptedPlan: FirebaseAdaptedPlan) -> Plan {
+    func toPlan(adaptedPlan: FirebaseAdaptedPlan) -> Plan {
         guard let planType = PlanType(rawValue: adaptedPlan.getType().rawValue) else {
             preconditionFailure()
         }

--- a/TourMate/TourMate/Shared/Adapters/TripAdapter.swift
+++ b/TourMate/TourMate/Shared/Adapters/TripAdapter.swift
@@ -1,0 +1,34 @@
+//
+//  TripAdapter.swift
+//  TourMate
+//
+//  Created by Keane Chan on 23/3/22.
+//
+
+class TripAdapter {
+    init() {}
+
+    func toAdaptedTrip(trip: Trip) -> FirebaseAdaptedTrip {
+        trip.toData()
+    }
+
+    func toTrip(adaptedTrip: FirebaseAdaptedTrip) -> Trip {
+        adaptedTrip.toItem()
+    }
+}
+
+extension Trip {
+    fileprivate func toData() -> FirebaseAdaptedTrip {
+        FirebaseAdaptedTrip(id: id, name: name, startDate: startDate, endDate: endDate, timeZone: timeZone,
+                            imageUrl: imageUrl, attendeesUserIds: attendeesUserIds, invitedUserIds: invitedUserIds,
+                            creationDate: creationDate, modificationDate: modificationDate)
+    }
+}
+
+extension FirebaseAdaptedTrip {
+    fileprivate func toItem() -> Trip {
+        Trip(id: id, name: name, startDate: startDate, endDate: endDate, timeZone: timeZone,
+             imageUrl: imageUrl, attendeesUserIds: attendeesUserIds, invitedUserIds: invitedUserIds,
+             creationDate: creationDate, modificationDate: modificationDate)
+    }
+}

--- a/TourMate/TourMate/Shared/Adapters/UserAdapter.swift
+++ b/TourMate/TourMate/Shared/Adapters/UserAdapter.swift
@@ -1,0 +1,30 @@
+//
+//  UserAdapter.swift
+//  TourMate
+//
+//  Created by Keane Chan on 23/3/22.
+//
+
+class UserAdapter {
+    init() {}
+
+    func toAdaptedUser(user: User) -> FirebaseAdaptedUser {
+        user.toData()
+    }
+
+    func toUser(adaptedUser: FirebaseAdaptedUser) -> User {
+        adaptedUser.toItem()
+    }
+}
+
+extension User {
+    fileprivate func toData() -> FirebaseAdaptedUser {
+        FirebaseAdaptedUser(id: id, name: name, email: email, imageUrl: imageUrl)
+    }
+}
+
+extension FirebaseAdaptedUser {
+    fileprivate func toItem() -> User {
+        User(id: id, name: name, email: email, imageUrl: imageUrl)
+    }
+}


### PR DESCRIPTION
- Remove the use of `super` on encoding and decoding of plans.  (Thanks @tanruiquan !)
- Add adapters as instance variables in firebase controllers

Closes #64 