### PR TITLE
Shift upvotes to a collection with its dedicated VM

### DIFF
--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -27,6 +27,14 @@
 		000AB55A27EE242500FF0ED3 /* PlanStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000AB55927EE242500FF0ED3 /* PlanStatusView.swift */; };
 		000F3BEF27F1659A00E7E2ED /* CommentIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000F3BED27F1659A00E7E2ED /* CommentIconView.swift */; };
 		000F3BF027F1659A00E7E2ED /* CommentTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000F3BEE27F1659A00E7E2ED /* CommentTextView.swift */; };
+		001D223527FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */; };
+		001D223727FEF3D600F42DB4 /* PlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223627FEF3D600F42DB4 /* PlanUpvote.swift */; };
+		001D223927FEF42B00F42DB4 /* PlanUpvoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */; };
+		001D223B27FEF47900F42DB4 /* PlanUpvoteEventDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223A27FEF47900F42DB4 /* PlanUpvoteEventDelegate.swift */; };
+		001D223D27FEF4CE00F42DB4 /* PlanUpvoteAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223C27FEF4CE00F42DB4 /* PlanUpvoteAdapter.swift */; };
+		001D223F27FEF5A400F42DB4 /* FirebasePlanUpvoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223E27FEF5A400F42DB4 /* FirebasePlanUpvoteService.swift */; };
+		001D224127FEF7D800F42DB4 /* MockPlanUpvoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D224027FEF7D800F42DB4 /* MockPlanUpvoteService.swift */; };
+		001D224327FEF8CC00F42DB4 /* PlanUpvoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D224227FEF8CC00F42DB4 /* PlanUpvoteViewModel.swift */; };
 		004981AB27E2FF3C007BDB2E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004981AA27E2FF3C007BDB2E /* SettingsView.swift */; };
 		004ACDB627F83DC60015CDD8 /* ViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ACDB527F83DC60015CDD8 /* ViewModelFactory.swift */; };
 		004ACDB827F89F370015CDD8 /* AdditionalInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004ACDB727F89F370015CDD8 /* AdditionalInfoView.swift */; };
@@ -178,6 +186,14 @@
 		000AB55927EE242500FF0ED3 /* PlanStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanStatusView.swift; sourceTree = "<group>"; };
 		000F3BED27F1659A00E7E2ED /* CommentIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentIconView.swift; path = Components/CommentIconView.swift; sourceTree = "<group>"; };
 		000F3BEE27F1659A00E7E2ED /* CommentTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentTextView.swift; path = Components/CommentTextView.swift; sourceTree = "<group>"; };
+		001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAdaptedPlanUpvote.swift; sourceTree = "<group>"; };
+		001D223627FEF3D600F42DB4 /* PlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvote.swift; sourceTree = "<group>"; };
+		001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteService.swift; sourceTree = "<group>"; };
+		001D223A27FEF47900F42DB4 /* PlanUpvoteEventDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteEventDelegate.swift; sourceTree = "<group>"; };
+		001D223C27FEF4CE00F42DB4 /* PlanUpvoteAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteAdapter.swift; sourceTree = "<group>"; };
+		001D223E27FEF5A400F42DB4 /* FirebasePlanUpvoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebasePlanUpvoteService.swift; sourceTree = "<group>"; };
+		001D224027FEF7D800F42DB4 /* MockPlanUpvoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPlanUpvoteService.swift; sourceTree = "<group>"; };
+		001D224227FEF8CC00F42DB4 /* PlanUpvoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteViewModel.swift; sourceTree = "<group>"; };
 		004981AA27E2FF3C007BDB2E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		004981AC27E3237A007BDB2E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		004ACDB527F83DC60015CDD8 /* ViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactory.swift; sourceTree = "<group>"; };
@@ -335,6 +351,7 @@
 			children = (
 				00062B4827EEEB4500267960 /* Components */,
 				00062B4527EEE8F300267960 /* UpvotePlanView.swift */,
+				001D224227FEF8CC00F42DB4 /* PlanUpvoteViewModel.swift */,
 			);
 			path = UpvotePlanView;
 			sourceTree = "<group>";
@@ -410,6 +427,14 @@
 			path = AttendeesView;
 			sourceTree = "<group>";
 		};
+		001D223327FEF10800F42DB4 /* PlanUpvote */ = {
+			isa = PBXGroup;
+			children = (
+				001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */,
+			);
+			path = PlanUpvote;
+			sourceTree = "<group>";
+		};
 		00582F7327E70F49008756E9 /* EditPlanView */ = {
 			isa = PBXGroup;
 			children = (
@@ -455,6 +480,7 @@
 			children = (
 				4C09661427F33F6300A00CE5 /* PlanEventDelegate.swift */,
 				4C26B46927F5D14800B8319E /* CommentEventDelegate.swift */,
+				001D223A27FEF47900F42DB4 /* PlanUpvoteEventDelegate.swift */,
 			);
 			path = Delegates;
 			sourceTree = "<group>";
@@ -584,6 +610,9 @@
 				B9A04FAB27E5567F007D4303 /* MockPlanService.swift */,
 				4CCBBD1A27DE651F00F9C250 /* FirebasePlanService.swift */,
 				B9B6B3FF27F5A95000B0F5F4 /* RealLocationService.swift */,
+				001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */,
+				001D223E27FEF5A400F42DB4 /* FirebasePlanUpvoteService.swift */,
+				001D224027FEF7D800F42DB4 /* MockPlanUpvoteService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -774,6 +803,7 @@
 				4CCBBD1E27DE67B400F9C250 /* PlanStatus.swift */,
 				4CCBBD2227DE687A00F9C250 /* Comment.swift */,
 				B98F35E827F02015000AFE53 /* Location.swift */,
+				001D223627FEF3D600F42DB4 /* PlanUpvote.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -804,6 +834,7 @@
 				4CE02B8027EACD6700480D73 /* Trip */,
 				4CE02B8127EACD6B00480D73 /* Plan */,
 				00062B5027EF115700267960 /* Comment */,
+				001D223327FEF10800F42DB4 /* PlanUpvote */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -860,6 +891,7 @@
 				4CE02B8C27EAE9CD00480D73 /* UserAdapter.swift */,
 				00062B4E27EF112300267960 /* CommentAdapter.swift */,
 				B9B6B3EE27F48CE800B0F5F4 /* LocationAdapter.swift */,
+				001D223C27FEF4CE00F42DB4 /* PlanUpvoteAdapter.swift */,
 			);
 			path = Adapters;
 			sourceTree = "<group>";
@@ -1431,6 +1463,7 @@
 				0092523E27DA574800F4F029 /* FirebaseAuthenticationService.swift in Sources */,
 				953570ED27E5BFDE000DF0C2 /* TripView.swift in Sources */,
 				4CB954DA27DDF499001410AD /* FirebaseAdaptedUser.swift in Sources */,
+				001D223D27FEF4CE00F42DB4 /* PlanUpvoteAdapter.swift in Sources */,
 				B9B6B40227F5AA5000B0F5F4 /* APIError.swift in Sources */,
 				95DEA1E827E6FCC500A74ED2 /* TripViewModel.swift in Sources */,
 				B9A04FAA27E4F584007D4303 /* AddPlanViewModel.swift in Sources */,
@@ -1444,15 +1477,19 @@
 				95DEA1EB27E721EB00A74ED2 /* BindingNilCoalescing.swift in Sources */,
 				953570E727E5BFBF000DF0C2 /* TripsView.swift in Sources */,
 				00062B6C27F0901C00267960 /* EditCommentView.swift in Sources */,
+				001D224327FEF8CC00F42DB4 /* PlanUpvoteViewModel.swift in Sources */,
+				001D223527FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift in Sources */,
 				4CE02B8D27EAE9CD00480D73 /* UserAdapter.swift in Sources */,
 				95D43CCF27F1703500B2E9FD /* PlansDayView.swift in Sources */,
 				B9B6B3EB27F46CC100B0F5F4 /* GeoapifyResult.swift in Sources */,
 				95D4261227F893750077A037 /* PlansView.swift in Sources */,
+				001D223927FEF42B00F42DB4 /* PlanUpvoteService.swift in Sources */,
 				B98F35F227F07D30000AFE53 /* AddressTextField.swift in Sources */,
 				95CB3F7727D8E79C0086E9E3 /* PlansListView.swift in Sources */,
 				00062B5E27F009F000267960 /* CommentListView.swift in Sources */,
 				4C55E7DB27F97AD30032D1D8 /* UIScreen+Extensions.swift in Sources */,
 				0092523827DA573500F4F029 /* LaunchView.swift in Sources */,
+				001D223727FEF3D600F42DB4 /* PlanUpvote.swift in Sources */,
 				00062B5227EF116F00267960 /* FirebaseAdaptedComment.swift in Sources */,
 				B9B6B3E127F43BEF00B0F5F4 /* AutocompleteQuery.swift in Sources */,
 				00062B5827EF387300267960 /* CommentsView.swift in Sources */,
@@ -1464,6 +1501,8 @@
 				4CCBBD2327DE687B00F9C250 /* Comment.swift in Sources */,
 				000F3BEF27F1659A00E7E2ED /* CommentIconView.swift in Sources */,
 				4CDE841C27EF12C7001F58C5 /* FirebaseEventDelegate.swift in Sources */,
+				001D223F27FEF5A400F42DB4 /* FirebasePlanUpvoteService.swift in Sources */,
+				001D223B27FEF47900F42DB4 /* PlanUpvoteEventDelegate.swift in Sources */,
 				00582F7027E70C97008756E9 /* EditPlanView.swift in Sources */,
 				95CB3F7627D8E79C0086E9E3 /* PlanCardView.swift in Sources */,
 				4CB954DE27DDFDB2001410AD /* Repository.swift in Sources */,
@@ -1482,6 +1521,7 @@
 				B9A1037C27E61E9200829BF4 /* PlanViewModel.swift in Sources */,
 				4CCBBD1B27DE651F00F9C250 /* FirebasePlanService.swift in Sources */,
 				4C8639A327DF37DA000566FB /* Constants.swift in Sources */,
+				001D224127FEF7D800F42DB4 /* MockPlanUpvoteService.swift in Sources */,
 				00F83BB827DC46E4003A28AA /* AuthenticationButton.swift in Sources */,
 				4CB954DC27DDFAA8001410AD /* FirebaseRepository.swift in Sources */,
 				B93B489427DA87A300478B7B /* FirebaseAdaptedPlan.swift in Sources */,

--- a/TourMate/TourMate/Backend/Persistence/Config/FirebaseConfig.swift
+++ b/TourMate/TourMate/Backend/Persistence/Config/FirebaseConfig.swift
@@ -12,6 +12,7 @@ final class FirebaseConfig {
     static let tripCollectionId = "trips"
     static let planCollectionId = "plans"
     static let commentCollectionId = "comments"
+    static let upvoteCollectionId = "planUpvotes"
 
     static func fieldPath(field: String) -> FieldPath {
         FieldPath(["base", field])

--- a/TourMate/TourMate/Backend/Persistence/Models/Base/FirebaseAdaptedType.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Base/FirebaseAdaptedType.swift
@@ -10,6 +10,7 @@ enum FirebaseAdaptedType: String, Codable {
     case firebaseAdaptedTrip
     case firebaseAdaptedComment
     case firebaseAdaptedPlan
+    case firebaseAdaptedPlanUpvote
 
     var metatype: FirebaseAdaptedData.Type {
         switch self {
@@ -21,6 +22,8 @@ enum FirebaseAdaptedType: String, Codable {
             return FirebaseAdaptedComment.self
         case .firebaseAdaptedPlan:
             return FirebaseAdaptedPlan.self
+        case .firebaseAdaptedPlanUpvote:
+            return FirebaseAdaptedPlanUpvote.self
         }
     }
 }

--- a/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedPlan.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/Plan/FirebaseAdaptedPlan.swift
@@ -19,7 +19,6 @@ class FirebaseAdaptedPlan: FirebaseAdaptedData {
     let status: String
     let creationDate: Date
     let modificationDate: Date
-    let upvotedUserIds: [String]
     var additionalInfo: String
     var ownerUserId: String
 
@@ -29,7 +28,6 @@ class FirebaseAdaptedPlan: FirebaseAdaptedData {
          startLocation: JsonAdaptedLocation?, endLocation: JsonAdaptedLocation?,
          imageUrl: String, status: String,
          creationDate: Date, modificationDate: Date,
-         upvotedUserIds: [String],
          additionalInfo: String, ownerUserId: String) {
         self.id = id
         self.tripId = tripId
@@ -42,7 +40,6 @@ class FirebaseAdaptedPlan: FirebaseAdaptedData {
         self.status = status
         self.creationDate = creationDate
         self.modificationDate = modificationDate
-        self.upvotedUserIds = upvotedUserIds
         self.additionalInfo = additionalInfo
         self.ownerUserId = ownerUserId
     }

--- a/TourMate/TourMate/Backend/Persistence/Models/PlanUpvote/FirebaseAdaptedPlanUpvote.swift
+++ b/TourMate/TourMate/Backend/Persistence/Models/PlanUpvote/FirebaseAdaptedPlanUpvote.swift
@@ -1,0 +1,25 @@
+//
+//  FirebaseAdaptedUpvote.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+struct FirebaseAdaptedPlanUpvote: FirebaseAdaptedData {
+    let id: String
+    let planId: String
+    let userId: String
+
+    init(planId: String, userId: String) {
+        self.id = planId + userId
+        self.planId = planId
+        self.userId = userId
+    }
+
+    func getType() -> FirebaseAdaptedType {
+        FirebaseAdaptedType.firebaseAdaptedPlanUpvote
+    }
+
+}

--- a/TourMate/TourMate/Frontend/Common/ViewModelFactory.swift
+++ b/TourMate/TourMate/Frontend/Common/ViewModelFactory.swift
@@ -81,6 +81,11 @@ struct ViewModelFactory {
                                  upperBoundDate: upperBoundDate)
     }
 
+    // PlanUpvotes
+    static func getPlanUpvoteViewModel(planViewModel: PlanViewModel) -> PlanUpvoteViewModel {
+        PlanUpvoteViewModel(planId: planViewModel.planId)
+    }
+
     // Comments
     static func getCommentsViewModel(planViewModel: PlanViewModel) -> CommentsViewModel {
         CommentsViewModel(planId: planViewModel.planId)

--- a/TourMate/TourMate/Frontend/Plan/Delegates/PlanUpvoteEventDelegate.swift
+++ b/TourMate/TourMate/Frontend/Plan/Delegates/PlanUpvoteEventDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  UpvoteEventDelegate.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+protocol PlanUpvoteEventDelegate: AnyObject {
+    func update(planUpvotes: [PlanUpvote], errorMessage: String) async
+}

--- a/TourMate/TourMate/Frontend/Plan/Models/Components/PlanUpvote.swift
+++ b/TourMate/TourMate/Frontend/Plan/Models/Components/PlanUpvote.swift
@@ -1,0 +1,20 @@
+//
+//  PlanUpvote.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+struct PlanUpvote {
+    let id: String
+    let planId: String
+    let userId: String
+
+    init(planId: String, userId: String) {
+        self.id = planId + userId
+        self.planId = planId
+        self.userId = userId
+    }
+}

--- a/TourMate/TourMate/Frontend/Plan/Models/Plan.swift
+++ b/TourMate/TourMate/Frontend/Plan/Models/Plan.swift
@@ -19,7 +19,6 @@ struct Plan: CustomStringConvertible {
     var status: PlanStatus
     let creationDate: Date
     let modificationDate: Date
-    var upvotedUserIds: [String]
     var additionalInfo: String
     var ownerUserId: String
 
@@ -39,7 +38,6 @@ struct Plan: CustomStringConvertible {
         self.status = status
         self.creationDate = Date()
         self.modificationDate = Date()
-        self.upvotedUserIds = []
         self.additionalInfo = additionalInfo
         self.ownerUserId = ownerUserId
     }
@@ -49,7 +47,7 @@ struct Plan: CustomStringConvertible {
          startLocation: Location? = nil, endLocation: Location? = nil,
          imageUrl: String = "", status: PlanStatus,
          creationDate: Date, modificationDate: Date,
-         upvotedUserIds: [String], additionalInfo: String = "",
+         additionalInfo: String = "",
          ownerUserId: String) {
         self.id = id
         self.tripId = tripId
@@ -62,7 +60,6 @@ struct Plan: CustomStringConvertible {
         self.status = status
         self.creationDate = creationDate
         self.modificationDate = modificationDate
-        self.upvotedUserIds = upvotedUserIds
         self.additionalInfo = additionalInfo
         self.ownerUserId = ownerUserId
     }

--- a/TourMate/TourMate/Frontend/Plan/Services/FirebasePlanUpvoteService.swift
+++ b/TourMate/TourMate/Frontend/Plan/Services/FirebasePlanUpvoteService.swift
@@ -1,0 +1,63 @@
+//
+//  FirebaseUpvoteService.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+class FirebasePlanUpvoteService: PlanUpvoteService {
+    private let firebaseRepository = FirebaseRepository(collectionId: FirebaseConfig.upvoteCollectionId)
+
+    private let planUpvoteAdapter = PlanUpvoteAdapter()
+
+    weak var planUpvoteEventDelegate: PlanUpvoteEventDelegate?
+
+    func fetchPlanUpvotesAndListen(withPlanId planId: String) async {
+        print("[FirebasePlanUpvoteService] Fetching and listening to plan upvotes")
+
+        firebaseRepository.eventDelegate = self
+        await firebaseRepository.fetchItemsAndListen(field: "planId", isEqualTo: planId)
+    }
+
+    func addPlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String) {
+        await firebaseRepository.addItem(id: planUpvote.id, item: planUpvoteAdapter.toAdaptedPlanUpvote(planUpvote: planUpvote))
+    }
+
+    func deletePlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String) {
+        await firebaseRepository.deleteItem(id: planUpvote.id)
+    }
+
+    func updatePlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String) {
+        await firebaseRepository.updateItem(id: planUpvote.id, item: planUpvoteAdapter.toAdaptedPlanUpvote(planUpvote: planUpvote))
+    }
+
+    func detachListener() {
+        firebaseRepository.eventDelegate = nil
+        firebaseRepository.detachListener()
+    }
+}
+
+// MARK: - FirebaseEventDelegate
+extension FirebasePlanUpvoteService: FirebaseEventDelegate {
+    func update(items: [FirebaseAdaptedData], errorMessage: String) async {
+        print("[FirebasePlanUpvoteService] Updating Plan upvotes")
+
+        guard errorMessage.isEmpty else {
+            await planUpvoteEventDelegate?.update(planUpvotes: [], errorMessage: errorMessage)
+            return
+        }
+
+        guard let adaptedPlanUpvotes = items as? [FirebaseAdaptedPlanUpvote] else {
+            await planUpvoteEventDelegate?.update(planUpvotes: [], errorMessage: Constants.errorPlanUpvoteConversion)
+            return
+        }
+
+        let planUpvotes = adaptedPlanUpvotes.map({ planUpvoteAdapter.toPlanUpvote(adaptedPlanUpvote: $0) })
+
+        await planUpvoteEventDelegate?.update(planUpvotes: planUpvotes, errorMessage: "")
+    }
+
+    func update(item: FirebaseAdaptedData?, errorMessage: String) async {}
+}

--- a/TourMate/TourMate/Frontend/Plan/Services/MockPlanService.swift
+++ b/TourMate/TourMate/Frontend/Plan/Services/MockPlanService.swift
@@ -18,8 +18,7 @@ class MockPlanService: PlanService {
              status: .confirmed,
              creationDate: creationDate,
              modificationDate: creationDate,
-             upvotedUserIds: [],
-            ownerUserId: "1"),
+             ownerUserId: "1"),
         Plan(id: "1", tripId: "0", name: "Visit Tower Bridge",
              startDateTime: DateTime(date: Date(timeIntervalSince1970: 1_651_460_400),
                                      timeZone: TimeZone(abbreviation: "PST")!),
@@ -28,7 +27,6 @@ class MockPlanService: PlanService {
              imageUrl: "https://source.unsplash.com/qxstzQ__HMk",
              status: .confirmed, creationDate: creationDate,
              modificationDate: creationDate,
-             upvotedUserIds: [],
              ownerUserId: "1"),
         Plan(id: "2", tripId: "0", name: "Dinner at Spago",
              startDateTime: DateTime(date: Date(timeIntervalSince1970: 1_651_460_400),
@@ -37,8 +35,7 @@ class MockPlanService: PlanService {
                                    timeZone: TimeZone(abbreviation: "PST")!),
              status: .confirmed, creationDate: creationDate,
              modificationDate: creationDate,
-             upvotedUserIds: [],
-            ownerUserId: "1"),
+             ownerUserId: "1"),
         Plan(id: "3", tripId: "1", name: "Travel to Kyoto",
              startDateTime: DateTime(date: Date(timeIntervalSince1970: 1_651_460_400),
                                      timeZone: TimeZone(abbreviation: "MST")!),
@@ -46,8 +43,7 @@ class MockPlanService: PlanService {
                                    timeZone: TimeZone(abbreviation: "MST")!),
              status: .confirmed, creationDate: creationDate,
              modificationDate: creationDate,
-             upvotedUserIds: [],
-            ownerUserId: "1"),
+             ownerUserId: "1"),
         Plan(id: "4", tripId: "1", name: "Flight to Japan",
              startDateTime: DateTime(date: Date(timeIntervalSince1970: 1_651_440_400),
                                      timeZone: TimeZone(abbreviation: "MST")!),
@@ -56,8 +52,7 @@ class MockPlanService: PlanService {
              imageUrl: "https://source.unsplash.com/pT0qBgNa0VU",
              status: .confirmed, creationDate: creationDate,
              modificationDate: creationDate,
-             upvotedUserIds: [],
-            ownerUserId: "1")
+             ownerUserId: "1")
     ]
 
     func addPlan(plan: Plan) async -> (Bool, String) {

--- a/TourMate/TourMate/Frontend/Plan/Services/MockPlanUpvoteService.swift
+++ b/TourMate/TourMate/Frontend/Plan/Services/MockPlanUpvoteService.swift
@@ -1,0 +1,44 @@
+//
+//  MockPlanUpvoteService.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+class MockPlanUpvoteService: PlanUpvoteService {
+    // From MockPlan and MockUsers
+    var planUpvotes = [
+        PlanUpvote(planId: "0", userId: "0"),
+        PlanUpvote(planId: "0", userId: "1"),
+        PlanUpvote(planId: "0", userId: "2")
+    ]
+    func fetchPlanUpvotesAndListen(withPlanId planId: String) async {
+    }
+
+    func addPlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String) {
+        planUpvotes.append(planUpvote)
+        return (true, "")
+    }
+
+    func deletePlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String) {
+        planUpvotes = planUpvotes.filter({ $0.id == planUpvote.id })
+        return (true, "")
+    }
+
+    func updatePlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String) {
+        guard let index = planUpvotes.firstIndex(where: { $0.id == planUpvote.id }) else {
+            return (false, "PlanUpvote with ID: \(planUpvote.id) should exist")
+        }
+
+        planUpvotes[index] = planUpvote
+        return (true, "")
+    }
+
+    weak var planUpvoteEventDelegate: PlanUpvoteEventDelegate?
+
+    func detachListener() {
+    }
+
+}

--- a/TourMate/TourMate/Frontend/Plan/Services/PlanUpvoteService.swift
+++ b/TourMate/TourMate/Frontend/Plan/Services/PlanUpvoteService.swift
@@ -1,0 +1,22 @@
+//
+//  UpvoteService.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+protocol PlanUpvoteService {
+    func fetchPlanUpvotesAndListen(withPlanId planId: String) async
+
+    func addPlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String)
+
+    func deletePlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String)
+
+    func updatePlanUpvote(planUpvote: PlanUpvote) async -> (Bool, String)
+
+    var planUpvoteEventDelegate: PlanUpvoteEventDelegate? { get set }
+
+    func detachListener()
+}

--- a/TourMate/TourMate/Frontend/Plan/Views/EditPlanView/EditPlanViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/EditPlanView/EditPlanViewModel.swift
@@ -62,7 +62,6 @@ class EditPlanViewModel: PlanFormViewModel {
         let imageUrl = planImageUrl
         let status = planStatus
         let creationDate = plan.creationDate
-        let upvotedUserIds = plan.upvotedUserIds
         let additionalInfo = planAdditionalInfo
         let ownerUserId = plan.ownerUserId
 
@@ -77,7 +76,6 @@ class EditPlanViewModel: PlanFormViewModel {
                                status: status,
                                creationDate: creationDate,
                                modificationDate: Date(),
-                               upvotedUserIds: upvotedUserIds,
                                additionalInfo: additionalInfo,
                                ownerUserId: ownerUserId)
 

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/PlanView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/PlanView.swift
@@ -9,14 +9,16 @@ import SwiftUI
 
 struct PlanView: View {
     @StateObject var planViewModel: PlanViewModel
-    @StateObject var commentsViewModel: CommentsViewModel
+    let commentsViewModel: CommentsViewModel
+    let planUpvoteViewModel: PlanUpvoteViewModel
     @State private var isShowingEditPlanSheet = false
 
     @Environment(\.dismiss) var dismiss
 
     init(planViewModel: PlanViewModel) {
         self._planViewModel = StateObject(wrappedValue: planViewModel)
-        self._commentsViewModel = StateObject(wrappedValue: ViewModelFactory.getCommentsViewModel(planViewModel: planViewModel))
+        self.commentsViewModel = ViewModelFactory.getCommentsViewModel(planViewModel: planViewModel)
+        self.planUpvoteViewModel = ViewModelFactory.getPlanUpvoteViewModel(planViewModel: planViewModel)
     }
 
     var body: some View {
@@ -33,7 +35,7 @@ struct PlanView: View {
                                planOwner: planViewModel.planOwner,
                                creationDateDisplay: planViewModel.creationDateDisplay)
 
-                UpvotePlanView(viewModel: planViewModel)
+                UpvotePlanView(viewModel: planUpvoteViewModel)
 
                 TimingView(startDate: planViewModel.startDateTimeDisplay,
                            endDate: planViewModel.endDateTimeDisplay)

--- a/TourMate/TourMate/Frontend/Plan/Views/PlansViews/Components/PlanBoxView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlansViews/Components/PlanBoxView.swift
@@ -9,9 +9,11 @@ import SwiftUI
 struct PlanBoxView: View {
 
     @StateObject var viewModel: PlanViewModel
+    let planUpvoteViewModel: PlanUpvoteViewModel
 
     init(viewModel: PlanViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
+        self.planUpvoteViewModel = ViewModelFactory.getPlanUpvoteViewModel(planViewModel: viewModel)
     }
 
     var body: some View {
@@ -25,7 +27,7 @@ struct PlanBoxView: View {
             }
             Text(viewModel.nameDisplay)
                 .font(.headline)
-            UpvotePlanView(viewModel: viewModel, displayName: false)
+            UpvotePlanView(viewModel: planUpvoteViewModel, displayName: false)
         }
         .padding()
         .contentShape(Rectangle())

--- a/TourMate/TourMate/Frontend/Plan/Views/PlansViews/Components/PlanCardView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlansViews/Components/PlanCardView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 struct PlanCardView: View {
 
     @StateObject var viewModel: PlanViewModel
+    let planUpvoteViewModel: PlanUpvoteViewModel
 
     init(viewModel: PlanViewModel) {
         self._viewModel = StateObject(wrappedValue: viewModel)
+        self.planUpvoteViewModel = ViewModelFactory.getPlanUpvoteViewModel(planViewModel: viewModel)
     }
 
     var body: some View {
@@ -34,7 +36,7 @@ struct PlanCardView: View {
 
             VStack {
                 Spacer()
-                UpvotePlanView(viewModel: viewModel, displayName: false)
+                UpvotePlanView(viewModel: planUpvoteViewModel, displayName: false)
                     .frame(maxWidth: UIScreen.screenWidth / 3)
                 Spacer()
 

--- a/TourMate/TourMate/Frontend/Plan/Views/UpvotePlanView/PlanUpvoteViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/UpvotePlanView/PlanUpvoteViewModel.swift
@@ -1,0 +1,126 @@
+//
+//  UpvotePlanViewModel.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+@MainActor
+class PlanUpvoteViewModel: ObservableObject {
+    @Published private(set) var isLoading = false
+    @Published private(set) var hasError = false
+
+    @Published private(set) var userHasUpvotedPlan = false
+    @Published private(set) var upvotedUsers: [User] = []
+
+    let planId: String
+
+    private let userService: UserService
+    private var planUpvoteService: PlanUpvoteService
+
+    init(planId: String,
+         userService: UserService = FirebaseUserService(),
+         planUpvoteService: PlanUpvoteService = FirebasePlanUpvoteService()) {
+
+        self.planId = planId
+        self.userService = userService
+        self.planUpvoteService = planUpvoteService
+    }
+
+    func fetchPlanUpvotesAndListen() async {
+        planUpvoteService.planUpvoteEventDelegate = self
+
+        self.isLoading = true
+        await planUpvoteService.fetchPlanUpvotesAndListen(withPlanId: planId)
+    }
+
+    func detachListener() {
+        planUpvoteService.planUpvoteEventDelegate = nil
+        self.isLoading = false
+
+        planUpvoteService.detachListener()
+    }
+
+    func upvotePlan() async {
+        self.isLoading = true
+
+        let (user, userErrorMessage) = await userService.getCurrentUser()
+
+        guard let user = user, userErrorMessage.isEmpty else {
+            handleError()
+            return
+        }
+
+        let userId = user.id
+        let planUpvote = PlanUpvote(planId: planId, userId: userId)
+
+        var updateSuccess: Bool
+        var errorMessage: String
+
+        if userHasUpvotedPlan {
+            (updateSuccess, errorMessage) = await planUpvoteService.deletePlanUpvote(planUpvote: planUpvote)
+        } else {
+            (updateSuccess, errorMessage) = await planUpvoteService.addPlanUpvote(planUpvote: planUpvote)
+        }
+
+        guard updateSuccess, errorMessage.isEmpty else {
+            handleError()
+            return
+        }
+
+        self.isLoading = false
+    }
+}
+
+// MARK: - PlanUpvoteEventDelegate
+extension PlanUpvoteViewModel: PlanUpvoteEventDelegate {
+    func update(planUpvotes: [PlanUpvote], errorMessage: String) async {
+        print("[PlanUpvoteViewModel] Updating Plan Upvotes")
+
+        guard errorMessage.isEmpty else {
+            handleError()
+            return
+        }
+
+        let (currentUser, currentUserErrorMessage) = await userService.getCurrentUser()
+
+        guard let currentUser = currentUser, currentUserErrorMessage.isEmpty else {
+            print("[PlanUpvoteViewModel] fetch user failed as Delegate")
+            handleError()
+            return
+        }
+
+        let userIds = planUpvotes.map({ $0.userId })
+
+        self.userHasUpvotedPlan = userIds.contains(currentUser.id)
+
+        var upvotedUsers: [User] = []
+
+        for userId in userIds {
+            let (user, userErrorMessage) = await userService.getUser(withUserId: userId)
+
+            if !userErrorMessage.isEmpty {
+                print("[PlanUpvoteViewModel] User cannot be found, upvote will not render")
+                continue
+            }
+
+            if let user = user {
+                upvotedUsers.append(user)
+            }
+        }
+
+        self.upvotedUsers = upvotedUsers
+
+        self.isLoading = false
+    }
+}
+
+// MARK: - Helper Methods
+extension PlanUpvoteViewModel {
+    private func handleError() {
+        self.hasError = true
+        self.isLoading = false
+    }
+}

--- a/TourMate/TourMate/Frontend/Plan/Views/UpvotePlanView/UpvotePlanView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/UpvotePlanView/UpvotePlanView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 struct UpvotePlanView: View {
 
-    @ObservedObject var viewModel: PlanViewModel
+    @StateObject var viewModel: PlanUpvoteViewModel
     let displayName: Bool
 
-    init(viewModel: PlanViewModel, displayName: Bool = true) {
-        self.viewModel = viewModel
+    init(viewModel: PlanUpvoteViewModel, displayName: Bool = true) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
         self.displayName = displayName
     }
 
@@ -25,6 +25,12 @@ struct UpvotePlanView: View {
             UpvotedUsersView(upvotedUsers: viewModel.upvotedUsers, displayName: displayName)
             Spacer()
         }
+        .onAppear {
+            Task {
+                await viewModel.fetchPlanUpvotesAndListen()
+            }
+        }
+        .onDisappear(perform: { () in viewModel.detachListener() })
     }
 }
 

--- a/TourMate/TourMate/Frontend/Trip/Views/TripView/TripViewModel.swift
+++ b/TourMate/TourMate/Frontend/Trip/Views/TripView/TripViewModel.swift
@@ -33,27 +33,27 @@ class TripViewModel: ObservableObject {
         self.tripService = tripService
         self.userService = userService
     }
-    
+
     var tripId: String {
         trip.id
     }
-    
+
     var nameDisplay: String {
         trip.name
     }
-    
+
     var startDateTime: DateTime {
         trip.startDateTime
     }
-    
+
     var endDateTime: DateTime {
         trip.endDateTime
     }
-    
+
     var durationDisplay: String {
         trip.durationDescription
     }
-    
+
     var imageUrlDisplay: String? {
         trip.imageUrl
     }

--- a/TourMate/TourMate/Shared/Adapters/PlanAdapter.swift
+++ b/TourMate/TourMate/Shared/Adapters/PlanAdapter.swift
@@ -26,7 +26,6 @@ extension Plan {
                             endLocation: endLocation?.toData(),
                             imageUrl: imageUrl, status: status.rawValue,
                             creationDate: creationDate, modificationDate: modificationDate,
-                            upvotedUserIds: upvotedUserIds,
                             additionalInfo: additionalInfo,
                             ownerUserId: ownerUserId)
     }
@@ -41,7 +40,6 @@ extension FirebaseAdaptedPlan {
              endLocation: endLocation?.toItem(),
              imageUrl: imageUrl, status: PlanStatus(rawValue: status)!,
              creationDate: creationDate, modificationDate: modificationDate,
-             upvotedUserIds: upvotedUserIds,
              additionalInfo: additionalInfo,
              ownerUserId: ownerUserId)
     }

--- a/TourMate/TourMate/Shared/Adapters/PlanUpvoteAdapter.swift
+++ b/TourMate/TourMate/Shared/Adapters/PlanUpvoteAdapter.swift
@@ -1,0 +1,32 @@
+//
+//  PlanUpvoteAdapter.swift
+//  TourMate
+//
+//  Created by Terence Ho on 7/4/22.
+//
+
+import Foundation
+
+class PlanUpvoteAdapter {
+    init() {}
+
+    func toAdaptedPlanUpvote(planUpvote: PlanUpvote) -> FirebaseAdaptedPlanUpvote {
+        planUpvote.toData()
+    }
+
+    func toPlanUpvote(adaptedPlanUpvote: FirebaseAdaptedPlanUpvote) -> PlanUpvote {
+        adaptedPlanUpvote.toItem()
+    }
+}
+
+extension PlanUpvote {
+    fileprivate func toData() -> FirebaseAdaptedPlanUpvote {
+        FirebaseAdaptedPlanUpvote(planId: planId, userId: userId)
+    }
+}
+
+extension FirebaseAdaptedPlanUpvote {
+    fileprivate func toItem() -> PlanUpvote {
+        PlanUpvote(planId: planId, userId: userId)
+    }
+}

--- a/TourMate/TourMate/Shared/Constants/Constants.swift
+++ b/TourMate/TourMate/Shared/Constants/Constants.swift
@@ -16,6 +16,9 @@ final class Constants {
     static let errorPlanConversion = "[FirebasePlanService] Error converting"
     + "FirebaseAdaptedData to FirebaseAdaptedPlan"
 
-    static let errorCommentConversion = "[FirebasePlanService] Error converting"
+    static let errorCommentConversion = "[FirebaseCommentService] Error converting"
     + "FirebaseAdaptedData to FirebaseAdaptedComment"
+
+    static let errorPlanUpvoteConversion = "[FirebasePlanUpvoteService] Error converting"
+    + "FirebaseAdaptedData to FirebaseAdaptedPlanUpvote"
 }


### PR DESCRIPTION
Created a new collection for Firebase: planUpvotes

Created new Model for plan upvoting. Upvoting ID = Plan ID + User ID.
- FirebaseAdaptedPlanUpvote
- PlanUpvote

Created new PlanUpvoteViewModel, PlanUpvoteService

Removed upvotedUserIds from Plan/FirebaseAdaptedPlan

