### PR TITLE
Fix bug

### DIFF
--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -1700,7 +1700,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TourMate/Preview Content\"";
-				DEVELOPMENT_TEAM = JH4N7Z4FH9;
+				DEVELOPMENT_TEAM = T83L3FZCTV;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TourMate/Misc/Info.plist;
@@ -1714,7 +1714,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.rlrh.TourMate;
+				PRODUCT_BUNDLE_IDENTIFIER = com.TourMate.rq;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanFormView/PlanFormViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanFormView/PlanFormViewModel.swift
@@ -42,7 +42,7 @@ class PlanFormViewModel: ObservableObject {
         self.planStatus = .proposed
         self.planName = ""
         self.planStartDate = lowerBoundDate
-        self.planEndDate = lowerBoundDate
+        self.planEndDate = lowerBoundDate + TimeInterval(3_600) // 1 hour
         self.planImageUrl = ""
         self.planAdditionalInfo = ""
 

--- a/TourMate/TourMate/Frontend/Plan/Views/PlansViews/PlansViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlansViews/PlansViewModel.swift
@@ -36,7 +36,7 @@ class PlansViewModel: ObservableObject {
                                                      month: components.month,
                                                      day: components.day)
             var date = Calendar.current.date(from: startDateComponents)!
-            while date < cur.endDateTime.date {
+            while date <= cur.endDateTime.date {
                 let existing = acc[date] ?? []
                 acc[date] = existing + [cur]
                 date = Calendar.current.date(byAdding: .day, value: 1, to: date)!


### PR DESCRIPTION
- `Plan` with the same start and end time is shown
- When adding a `Plan`, defaults to `endTime` = `startTime` + 1 hour but user can still change it to a smaller interval if they want 

Closes #146 