### PR TITLE
Comments cleanup

### DIFF
--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		000AB55A27EE242500FF0ED3 /* PlanStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000AB55927EE242500FF0ED3 /* PlanStatusView.swift */; };
 		000F3BEF27F1659A00E7E2ED /* CommentIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000F3BED27F1659A00E7E2ED /* CommentIconView.swift */; };
 		000F3BF027F1659A00E7E2ED /* CommentTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000F3BEE27F1659A00E7E2ED /* CommentTextView.swift */; };
+		00148C952807E5A60091C28B /* AddCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C942807E5A60091C28B /* AddCommentView.swift */; };
+		00148C982807E6720091C28B /* AddCommentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C972807E6720091C28B /* AddCommentViewModel.swift */; };
+		00148C9B2807E7A60091C28B /* ViewModelFactory+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */; };
 		001D223527FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */; };
 		001D223727FEF3D600F42DB4 /* PlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223627FEF3D600F42DB4 /* PlanUpvote.swift */; };
 		001D223927FEF42B00F42DB4 /* PlanUpvoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */; };
@@ -230,6 +233,9 @@
 		000AB55927EE242500FF0ED3 /* PlanStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanStatusView.swift; sourceTree = "<group>"; };
 		000F3BED27F1659A00E7E2ED /* CommentIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentIconView.swift; path = Components/CommentIconView.swift; sourceTree = "<group>"; };
 		000F3BEE27F1659A00E7E2ED /* CommentTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentTextView.swift; path = Components/CommentTextView.swift; sourceTree = "<group>"; };
+		00148C942807E5A60091C28B /* AddCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentView.swift; sourceTree = "<group>"; };
+		00148C972807E6720091C28B /* AddCommentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentViewModel.swift; sourceTree = "<group>"; };
+		00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModelFactory+Comments.swift"; sourceTree = "<group>"; };
 		001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAdaptedPlanUpvote.swift; sourceTree = "<group>"; };
 		001D223627FEF3D600F42DB4 /* PlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvote.swift; sourceTree = "<group>"; };
 		001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteService.swift; sourceTree = "<group>"; };
@@ -466,6 +472,7 @@
 			children = (
 				00062B6A27F01A7600267960 /* CommentsView */,
 				00062B6227F010D300267960 /* CommentView */,
+				00148C962807E64C0091C28B /* AddCommentView */,
 			);
 			path = CommentViews;
 			sourceTree = "<group>";
@@ -513,6 +520,24 @@
 				000AB55327EE184F00FF0ED3 /* AttendeesView.swift */,
 			);
 			path = AttendeesView;
+			sourceTree = "<group>";
+		};
+		00148C962807E64C0091C28B /* AddCommentView */ = {
+			isa = PBXGroup;
+			children = (
+				00148C942807E5A60091C28B /* AddCommentView.swift */,
+				00148C972807E6720091C28B /* AddCommentViewModel.swift */,
+			);
+			path = AddCommentView;
+			sourceTree = "<group>";
+		};
+		00148C992807E7900091C28B /* ViewModelFactory */ = {
+			isa = PBXGroup;
+			children = (
+				004ACDB527F83DC60015CDD8 /* ViewModelFactory.swift */,
+				00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */,
+			);
+			path = ViewModelFactory;
 			sourceTree = "<group>";
 		};
 		001D223327FEF10800F42DB4 /* PlanUpvote */ = {
@@ -1282,7 +1307,7 @@
 			children = (
 				B9A360C027EC076500030769 /* DateTime.swift */,
 				95D4260F27F891FB0077A037 /* View+readSize.swift */,
-				004ACDB527F83DC60015CDD8 /* ViewModelFactory.swift */,
+				00148C992807E7900091C28B /* ViewModelFactory */,
 				4C55E7DA27F97AD20032D1D8 /* UIScreen+Extensions.swift */,
 				4CD10A7727FF3A310060C5AC /* DateUtil.swift */,
 				4C16604F2800A4BD00195DF8 /* Copyable.swift */,
@@ -1705,6 +1730,8 @@
 				4C1C70D327FE82C800203694 /* PlanHeaderView.swift in Sources */,
 				4C09661527F33F6400A00CE5 /* PlanEventDelegate.swift in Sources */,
 				4CB32D78280576A800681E5B /* ViewFactory.swift in Sources */,
+				00148C952807E5A60091C28B /* AddCommentView.swift in Sources */,
+				00148C9B2807E7A60091C28B /* ViewModelFactory+Comments.swift in Sources */,
 				B9A04FAC27E5567F007D4303 /* MockPlanService.swift in Sources */,
 				4C1660502800A4BD00195DF8 /* Copyable.swift in Sources */,
 				4C09373B27F83654001C2575 /* TripImage.swift in Sources */,
@@ -1764,6 +1791,7 @@
 				001D223727FEF3D600F42DB4 /* PlanUpvote.swift in Sources */,
 				B9B467262801DA61003D07F5 /* AddAccommodationViewModel.swift in Sources */,
 				00062B5227EF116F00267960 /* FirebaseAdaptedComment.swift in Sources */,
+				00148C982807E6720091C28B /* AddCommentViewModel.swift in Sources */,
 				B9B46722280182A4003D07F5 /* ViewExtension.swift in Sources */,
 				004C7C5D2802770E00B432C7 /* AuthenticationServiceDelegate.swift in Sources */,
 				B9B6B3E127F43BEF00B0F5F4 /* AutocompleteQuery.swift in Sources */,
@@ -1983,7 +2011,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TourMate/Preview Content\"";
-				DEVELOPMENT_TEAM = U2PZ23X6W5;
+				DEVELOPMENT_TEAM = 9T2CK64XKZ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TourMate/Misc/Info.plist;
@@ -1997,7 +2025,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.TourMate.k;
+				PRODUCT_BUNDLE_IDENTIFIER = com.TourMate.terence;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		00148C952807E5A60091C28B /* AddCommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C942807E5A60091C28B /* AddCommentView.swift */; };
 		00148C982807E6720091C28B /* AddCommentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C972807E6720091C28B /* AddCommentViewModel.swift */; };
 		00148C9B2807E7A60091C28B /* ViewModelFactory+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */; };
+		00148CA728080A260091C28B /* CommentInteractionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148CA628080A260091C28B /* CommentInteractionView.swift */; };
 		001D223527FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */; };
 		001D223727FEF3D600F42DB4 /* PlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223627FEF3D600F42DB4 /* PlanUpvote.swift */; };
 		001D223927FEF42B00F42DB4 /* PlanUpvoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */; };
@@ -236,6 +237,7 @@
 		00148C942807E5A60091C28B /* AddCommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentView.swift; sourceTree = "<group>"; };
 		00148C972807E6720091C28B /* AddCommentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentViewModel.swift; sourceTree = "<group>"; };
 		00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModelFactory+Comments.swift"; sourceTree = "<group>"; };
+		00148CA628080A260091C28B /* CommentInteractionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentInteractionView.swift; sourceTree = "<group>"; };
 		001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAdaptedPlanUpvote.swift; sourceTree = "<group>"; };
 		001D223627FEF3D600F42DB4 /* PlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvote.swift; sourceTree = "<group>"; };
 		001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteService.swift; sourceTree = "<group>"; };
@@ -492,6 +494,7 @@
 			children = (
 				000F3BED27F1659A00E7E2ED /* CommentIconView.swift */,
 				000F3BEE27F1659A00E7E2ED /* CommentTextView.swift */,
+				00148CA628080A260091C28B /* CommentInteractionView.swift */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -1832,6 +1835,7 @@
 				4CCBBD1B27DE651F00F9C250 /* FirebasePlanService.swift in Sources */,
 				B9B4671C280070A7003D07F5 /* EditActivityViewModel.swift in Sources */,
 				4C8639A327DF37DA000566FB /* Constants.swift in Sources */,
+				00148CA728080A260091C28B /* CommentInteractionView.swift in Sources */,
 				B9B4671A28006976003D07F5 /* ActivityViewModel.swift in Sources */,
 				001D224127FEF7D800F42DB4 /* MockPlanUpvoteService.swift in Sources */,
 				B9B4671E280075E0003D07F5 /* FirebaseAdaptedActivity.swift in Sources */,

--- a/TourMate/TourMate/Frontend/Common/ViewModelFactory/ViewModelFactory+Comments.swift
+++ b/TourMate/TourMate/Frontend/Common/ViewModelFactory/ViewModelFactory+Comments.swift
@@ -1,0 +1,27 @@
+//
+//  ViewModelFactory+Comments.swift
+//  TourMate
+//
+//  Created by Terence Ho on 14/4/22.
+//
+
+import Foundation
+
+extension ViewModelFactory {
+    // Comments
+    func getCommentsViewModel<T: Plan>(planViewModel: PlanViewModel<T>) -> CommentsViewModel {
+        getCommentsViewModel(plan: planViewModel.plan)
+    }
+
+    func getCommentsViewModel(plan: Plan) -> CommentsViewModel {
+        CommentsViewModel(planId: plan.id, planVersionNumber: plan.versionNumber,
+                          commentService: commentService.copy(), userService: userService)
+    }
+
+    func getAddCommentViewModel(commentsViewModel: CommentsViewModel) -> AddCommentViewModel {
+        AddCommentViewModel(planId: commentsViewModel.planId,
+                            planVersionNumber: commentsViewModel.planVersionNumber,
+                            commentService: commentService.copy(),
+                            userService: userService)
+    }
+}

--- a/TourMate/TourMate/Frontend/Common/ViewModelFactory/ViewModelFactory.swift
+++ b/TourMate/TourMate/Frontend/Common/ViewModelFactory/ViewModelFactory.swift
@@ -147,16 +147,6 @@ struct ViewModelFactory {
                             userService: userService, planUpvoteService: planUpvoteService.copy())
     }
 
-    // Comments
-    func getCommentsViewModel<T: Plan>(planViewModel: PlanViewModel<T>) -> CommentsViewModel {
-        getCommentsViewModel(plan: planViewModel.plan)
-    }
-
-    func getCommentsViewModel(plan: Plan) -> CommentsViewModel {
-        CommentsViewModel(planId: plan.id, planVersionNumber: plan.versionNumber,
-                          commentService: commentService.copy(), userService: userService)
-    }
-
     // Search
     func getSearchViewModel() -> SearchViewModel {
         SearchViewModel(locationService: locationService)

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/AddCommentView/AddCommentView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/AddCommentView/AddCommentView.swift
@@ -1,0 +1,35 @@
+//
+//  AddCommentView.swift
+//  TourMate
+//
+//  Created by Terence Ho on 14/4/22.
+//
+
+import SwiftUI
+
+struct AddCommentView: View {
+    @StateObject var viewModel: AddCommentViewModel
+
+    var body: some View {
+        HStack(alignment: .center) {
+            TextField("Add a comment", text: $viewModel.commentField)
+                .padding()
+                .background(Color.primary.colorInvert())
+                .cornerRadius(20.0)
+
+            Button {
+                Task {
+                    await viewModel.addComment()
+                }
+            } label: {
+                Image(systemName: "paperplane.fill")
+            }
+        }
+    }
+}
+
+// struct AddCommentView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        AddCommentView()
+//    }
+// }

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/AddCommentView/AddCommentViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/AddCommentView/AddCommentViewModel.swift
@@ -1,0 +1,83 @@
+//
+//  AddCommentViewModel.swift
+//  TourMate
+//
+//  Created by Terence Ho on 14/4/22.
+//
+
+import Foundation
+
+@MainActor
+class AddCommentViewModel: ObservableObject {
+    @Published var isLoading: Bool
+    @Published var hasError: Bool
+
+    @Published var commentField: String
+
+    private let planId: String
+    private var planVersionNumber: Int
+    private var commentService: CommentService
+    private let userService: UserService
+
+    init(planId: String,
+         planVersionNumber: Int,
+         commentService: CommentService,
+         userService: UserService) {
+
+        self.isLoading = false
+        self.hasError = false
+
+        self.commentField = ""
+
+        self.planId = planId
+        self.planVersionNumber = planVersionNumber
+        self.commentService = commentService
+        self.userService = userService
+    }
+
+    func addComment() async {
+        guard !commentField.isEmpty else {
+            return
+        }
+
+        self.isLoading = true
+
+        let (user, userErrorMessage) = await userService.getCurrentUser()
+
+        guard let user = user, userErrorMessage.isEmpty else {
+            print("[AddCommentViewModel] fetch user failed in addComment()")
+            handleError()
+            return
+        }
+
+        let userId = user.id
+        let commentId = planId + "-" + String(planVersionNumber) + "-" + UUID().uuidString
+
+        let comment = Comment(planId: planId,
+                              planVersionNumber: planVersionNumber,
+                              id: commentId,
+                              userId: userId,
+                              message: commentField,
+                              creationDate: Date(),
+                              upvotedUserIds: [])
+
+        let (hasAdded, commentErrorMessage) = await commentService.addComment(comment: comment)
+
+        guard hasAdded, commentErrorMessage.isEmpty else {
+            print("[AddCommentViewModel] add comment failed in addComment()")
+            handleError()
+            return
+        }
+
+        self.commentField = ""
+        self.isLoading = false
+    }
+}
+
+// MARK: - State changes
+extension AddCommentViewModel {
+    private func handleError() {
+        self.hasError = true
+        self.isLoading = false
+    }
+}

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/CommentInteractionView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/CommentInteractionView.swift
@@ -1,0 +1,71 @@
+//
+//  CommentInteractionVieq.swift
+//  TourMate
+//
+//  Created by Terence Ho on 14/4/22.
+//
+
+import SwiftUI
+
+struct CommentInteractionView: View {
+    @ObservedObject var viewModel: CommentsViewModel
+    var comment: Comment
+
+    @State var isShowingEditCommentSheet = false
+
+    var upvoteImageName: String {
+        let userHasUpvotedComment = viewModel.getUserHasUpvotedComment(comment: comment)
+        if userHasUpvotedComment {
+            return "hand.thumbsup.fill"
+        } else {
+            return "hand.thumbsup"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 10.0) {
+            if viewModel.getUserCanEditComment(comment: comment) {
+                Button {
+                    self.isShowingEditCommentSheet = true
+                } label: {
+                    Text("Edit")
+                        .foregroundColor(.blue)
+                        .padding([.vertical], 4.0)
+                }
+            }
+
+            Button {
+                Task {
+                    await viewModel.upvoteComment(comment: comment)
+                }
+            } label: {
+                HStack {
+                    Image(systemName: upvoteImageName)
+                        .foregroundColor(.blue)
+
+                    Text(String(comment.upvotedUserIds.count))
+                        .foregroundColor(.black)
+                }
+                .padding([.horizontal], 10.0)
+                .padding([.vertical], 4.0)
+                .background(.white)
+                .cornerRadius(20.0)
+            }
+
+            Spacer()
+        }
+        .disabled(viewModel.isLoading || viewModel.hasError)
+        .sheet(isPresented: $isShowingEditCommentSheet) {
+            // on dismiss
+            print("Sheet dismissed")
+        } content: {
+            EditCommentView(viewModel: viewModel, comment: comment)
+        }
+    }
+}
+
+// struct CommentInteractionVieq_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CommentInteractionView()
+//    }
+// }

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/CommentInteractionView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/CommentInteractionView.swift
@@ -13,15 +13,6 @@ struct CommentInteractionView: View {
 
     @State var isShowingEditCommentSheet = false
 
-    var upvoteImageName: String {
-        let userHasUpvotedComment = viewModel.getUserHasUpvotedComment(comment: comment)
-        if userHasUpvotedComment {
-            return "hand.thumbsup.fill"
-        } else {
-            return "hand.thumbsup"
-        }
-    }
-
     var body: some View {
         HStack(spacing: 10.0) {
             if viewModel.getUserCanEditComment(comment: comment) {
@@ -40,10 +31,10 @@ struct CommentInteractionView: View {
                 }
             } label: {
                 HStack {
-                    Image(systemName: upvoteImageName)
+                    Image(systemName: viewModel.getUpvoteImageNameDisplay(comment: comment))
                         .foregroundColor(.blue)
 
-                    Text(String(comment.upvotedUserIds.count))
+                    Text(viewModel.getUpvoteUserCountDisplay(comment: comment))
                         .foregroundColor(.black)
                 }
                 .padding([.horizontal], 10.0)

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/CommentView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/CommentView.swift
@@ -18,11 +18,15 @@ struct CommentView: View {
         HStack(alignment: .bottom, spacing: 10.0) { // telegram style alignment
             CommentIconView(imageUrl: user.imageUrl)
 
-            CommentTextView(viewModel: viewModel, user: user, comment: comment)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
-                .background(.white)
-                .cornerRadius(20)
+            VStack(alignment: .leading, spacing: 10.0) {
+                CommentTextView(user: user, comment: comment)
+
+                CommentInteractionView(viewModel: viewModel, comment: comment)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(.white)
+            .cornerRadius(20)
         }
     }
 }

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/Components/CommentTextView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentView/Components/CommentTextView.swift
@@ -8,84 +8,29 @@
 import SwiftUI
 
 struct CommentTextView: View {
-    @ObservedObject var viewModel: CommentsViewModel
+
     var user: User
     var comment: Comment
 
-    @State var isShowingEditCommentSheet = false
-
-    var upvoteImageName: String {
-        let userHasUpvotedComment = viewModel.getUserHasUpvotedComment(comment: comment)
-        if userHasUpvotedComment {
-            return "hand.thumbsup.fill"
-        } else {
-            return "hand.thumbsup"
-        }
-    }
-
-    init(viewModel: CommentsViewModel, user: User, comment: Comment) {
-        self.viewModel = viewModel
+    init(user: User, comment: Comment) {
         self.user = user
         self.comment = comment
     }
 
     var body: some View {
-        if viewModel.hasError {
-            Text("Error occured")
-        } else {
-            VStack(alignment: .leading, spacing: 10.0) {
-                HStack(alignment: .top, spacing: 5.0) {
-                    Text(user.name)
-                        .bold()
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    Spacer()
-
-                    Text(comment.creationDateDescription)
-                }
-
-                Text(comment.message)
+        VStack(alignment: .leading, spacing: 10.0) {
+            HStack(alignment: .top, spacing: 5.0) {
+                Text(user.name)
+                    .bold()
                     .fixedSize(horizontal: false, vertical: true)
 
-                HStack(spacing: 10.0) {
-                    if viewModel.getUserCanEditComment(comment: comment) {
-                        Button {
-                            self.isShowingEditCommentSheet = true
-                        } label: {
-                            Text("Edit")
-                                .foregroundColor(.blue)
-                                .padding([.vertical], 4.0)
-                        }
-                    }
+                Spacer()
 
-                    Button {
-                        Task {
-                            await viewModel.upvoteComment(comment: comment)
-                        }
-                    } label: {
-                        HStack {
-                            Image(systemName: upvoteImageName)
-                                .foregroundColor(.blue)
-
-                            Text(String(comment.upvotedUserIds.count))
-                                .foregroundColor(.black)
-                        }
-                        .padding([.horizontal], 10.0)
-                        .padding([.vertical], 4.0)
-                        .background(.white)
-                        .cornerRadius(20.0)
-                    }
-
-                    Spacer()
-                }
+                Text(comment.creationDateDescription)
             }
-            .disabled(viewModel.isLoading || viewModel.hasError)
-            .sheet(isPresented: $isShowingEditCommentSheet) {
-                // on dismiss
-                print("Sheet dismissed")
-            } content: {
-                EditCommentView(viewModel: viewModel, comment: comment)
-            }
+
+            Text(comment.message)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentListView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentListView.swift
@@ -20,6 +20,12 @@ struct CommentListView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading) // Push all comments to leading
         }
         .frame(maxWidth: .infinity, maxHeight: 500.0, alignment: .leading) // push VStack to leading
+        .onAppear {
+            Task {
+                await viewModel.fetchCommentsAndListen()
+            }
+        }
+        .onDisappear(perform: { () in viewModel.detachListener() })
     }
 }
 

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsView.swift
@@ -24,12 +24,6 @@ struct CommentsView: View {
             .padding()
             .background(.thinMaterial)
             .cornerRadius(20.0)
-            .onAppear {
-                Task {
-                    await viewModel.fetchCommentsAndListen()
-                }
-            }
-            .onDisappear(perform: { () in viewModel.detachListener() })
         }
     }
 }

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 // Entire Comments View
 struct CommentsView: View {
     @StateObject var viewModel: CommentsViewModel
-    @State var commentMessage: String = ""
     private let viewModelFactory = ViewModelFactory()
 
     var body: some View {

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CommentsView: View {
     @StateObject var viewModel: CommentsViewModel
     @State var commentMessage: String = ""
+    private let viewModelFactory = ViewModelFactory()
 
     var body: some View {
         if viewModel.hasError {
@@ -19,22 +20,7 @@ struct CommentsView: View {
             VStack(spacing: 15.0) {
                 CommentListView(viewModel: viewModel)
 
-                HStack {
-                    TextField("Add a comment", text: $commentMessage)
-                        .padding()
-                        .background(.white)
-                        .cornerRadius(20.0)
-
-                    Button {
-                        Task {
-                            await viewModel.addComment(commentMessage: commentMessage)
-                            commentMessage = ""
-                        }
-                    } label: {
-                        Image(systemName: "paperplane.fill")
-                    }
-                    .disabled(viewModel.isLoading || viewModel.hasError)
-                }
+                AddCommentView(viewModel: viewModelFactory.getAddCommentViewModel(commentsViewModel: viewModel))
             }
             .padding()
             .background(.thinMaterial)

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsViewModel.swift
@@ -131,6 +131,19 @@ class CommentsViewModel: ObservableObject {
         return canEdit
     }
 
+    func getUpvoteImageNameDisplay(comment: Comment) -> String {
+        let userHasUpvotedComment = getUserHasUpvotedComment(comment: comment)
+        if userHasUpvotedComment {
+            return "hand.thumbsup.fill"
+        } else {
+            return "hand.thumbsup"
+        }
+    }
+
+    func getUpvoteUserCountDisplay(comment: Comment) -> String {
+        String(comment.upvotedUserIds.count)
+    }
+
     func detachListener() {
         commentService.commentEventDelegate = nil
         self.isLoading = false

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsViewModel.swift
@@ -18,7 +18,8 @@ class CommentsViewModel: ObservableObject {
     private(set) var commentService: CommentService
     let userService: UserService
 
-    private var commentPermissions: [String: (Bool, Bool)] = [:] // canEdit, userHasUpvotedComment
+    private var commentPermissions: [String: (Bool, Bool)] // canEdit, userHasUpvotedComment
+    var allowUserInteraction: Bool
 
     var commentCount: Int {
         commentOwnerPairs.count
@@ -27,17 +28,20 @@ class CommentsViewModel: ObservableObject {
     init(planId: String,
          planVersionNumber: Int,
          commentService: CommentService,
-         userService: UserService) {
+         userService: UserService,
+         allowUserInteraction: Bool = true) {
+
+        self.commentOwnerPairs = []
+        self.isLoading = false
+        self.hasError = false
 
         self.planId = planId
         self.planVersionNumber = planVersionNumber
         self.commentService = commentService
         self.userService = userService
 
-        self.commentOwnerPairs = []
-
-        self.isLoading = false
-        self.hasError = false
+        self.commentPermissions = [:]
+        self.allowUserInteraction = allowUserInteraction
     }
 
     // TODO: Ensure that we detach and attach listeners properly when switching

--- a/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/CommentViews/CommentsView/CommentsViewModel.swift
@@ -13,10 +13,10 @@ class CommentsViewModel: ObservableObject {
     @Published var isLoading: Bool
     @Published var hasError: Bool
 
-    private let planId: String
-    private var planVersionNumber: Int
-    private var commentService: CommentService
-    private let userService: UserService
+    let planId: String
+    private(set) var planVersionNumber: Int
+    private(set) var commentService: CommentService
+    let userService: UserService
 
     private var commentPermissions: [String: (Bool, Bool)] = [:] // canEdit, userHasUpvotedComment
 
@@ -56,43 +56,6 @@ class CommentsViewModel: ObservableObject {
 
         self.isLoading = true
         await commentService.fetchVersionedCommentsAndListen(withPlanId: planId, versionNumber: planVersionNumber)
-    }
-
-    func addComment(commentMessage: String) async {
-        guard !commentMessage.isEmpty else {
-            return
-        }
-
-        self.isLoading = true
-
-        let (user, userErrorMessage) = await userService.getCurrentUser()
-
-        guard let user = user, userErrorMessage.isEmpty else {
-            print("[CommentsViewModel] fetch user failed in addComment()")
-            handleError()
-            return
-        }
-
-        let userId = user.id
-        let commentId = planId + "-" + String(planVersionNumber) + "-" + UUID().uuidString
-
-        let comment = Comment(planId: planId,
-                              planVersionNumber: planVersionNumber,
-                              id: commentId,
-                              userId: userId,
-                              message: commentMessage,
-                              creationDate: Date(),
-                              upvotedUserIds: [])
-
-        let (hasAdded, commentErrorMessage) = await commentService.addComment(comment: comment)
-
-        guard hasAdded, commentErrorMessage.isEmpty else {
-            print("[CommentsViewModel] add comment failed in addComment()")
-            handleError()
-            return
-        }
-
-        self.isLoading = false
     }
 
     func deleteComment(comment: Comment) async {


### PR DESCRIPTION
Shifted add comments logic to AddCommentsViewModel
Shifted Upvote and Edit Comment into a `CommentInteractionView`
- Just to make CommentView a bit cleaner

I tried to decouple the Editing and Upvote from CommentsViewModel into an `EditCommentViewModel`, but right now we are fetching and listening to comments as an entire collection (we don't listen to comments individually unlike Plans/Trips). The entire state of the comments is managed inside the CommentsVM, and it can optimise the re-rendering under the hood. 

But by separating them into individual Comment View Models, the VM has to manage the state for each comment (computing if the user can edit, has upvoted etc). When CommentsViewModel fetches an update from Firebase, these VMs will re-render the state (causing flickering in the Edit/Upvote part of the CommentView).

For now I can't think of a way to decouple the views furthe