### PR TITLE
change Additional Info to text view

### DIFF
--- a/TourMate/TourMate.xcodeproj/project.pbxproj
+++ b/TourMate/TourMate.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		00148C982807E6720091C28B /* AddCommentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C972807E6720091C28B /* AddCommentViewModel.swift */; };
 		00148C9B2807E7A60091C28B /* ViewModelFactory+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */; };
 		00148CA728080A260091C28B /* CommentInteractionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148CA628080A260091C28B /* CommentInteractionView.swift */; };
+		00148CB2280903A50091C28B /* ExpandableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00148CB1280903A50091C28B /* ExpandableTextView.swift */; };
 		001D223527FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */; };
 		001D223727FEF3D600F42DB4 /* PlanUpvote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223627FEF3D600F42DB4 /* PlanUpvote.swift */; };
 		001D223927FEF42B00F42DB4 /* PlanUpvoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */; };
@@ -238,6 +239,7 @@
 		00148C972807E6720091C28B /* AddCommentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommentViewModel.swift; sourceTree = "<group>"; };
 		00148C9A2807E7A60091C28B /* ViewModelFactory+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewModelFactory+Comments.swift"; sourceTree = "<group>"; };
 		00148CA628080A260091C28B /* CommentInteractionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentInteractionView.swift; sourceTree = "<group>"; };
+		00148CB1280903A50091C28B /* ExpandableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableTextView.swift; sourceTree = "<group>"; };
 		001D223427FEF11D00F42DB4 /* FirebaseAdaptedPlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAdaptedPlanUpvote.swift; sourceTree = "<group>"; };
 		001D223627FEF3D600F42DB4 /* PlanUpvote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvote.swift; sourceTree = "<group>"; };
 		001D223827FEF42B00F42DB4 /* PlanUpvoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanUpvoteService.swift; sourceTree = "<group>"; };
@@ -1316,6 +1318,7 @@
 				4C16604F2800A4BD00195DF8 /* Copyable.swift */,
 				004C7C6E28041A6F00B432C7 /* DisplayMode.swift */,
 				4CB32D77280576A800681E5B /* ViewFactory.swift */,
+				00148CB1280903A50091C28B /* ExpandableTextView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1750,6 +1753,7 @@
 				B99D964927D73503009B66AE /* TourMateApp.swift in Sources */,
 				95779BD927E769FD001FF602 /* UserService.swift in Sources */,
 				0092523E27DA574800F4F029 /* FirebaseAuthenticationService.swift in Sources */,
+				00148CB2280903A50091C28B /* ExpandableTextView.swift in Sources */,
 				B98F35ED27F05F0D000AFE53 /* MockLocationService.swift in Sources */,
 				B9B4671328003174003D07F5 /* AddActivityView.swift in Sources */,
 				95779BD927E769FD001FF602 /* UserService.swift in Sources */,

--- a/TourMate/TourMate/Frontend/Common/ExpandableTextView.swift
+++ b/TourMate/TourMate/Frontend/Common/ExpandableTextView.swift
@@ -1,0 +1,58 @@
+//
+//  ExpandableTextView.swift
+//  TourMate
+//
+//  Created by Terence Ho on 15/4/22.
+//
+
+import SwiftUI
+
+struct ExpandableTextView: View {
+
+    @State private var isExpanded = false
+    let content: String
+    let allowedLineLimit: Int
+
+    init(content: String, allowedLineLimit: Int = 3) {
+        self.content = content
+        self.allowedLineLimit = allowedLineLimit
+    }
+
+    var lineLimit: Int? {
+        if isExpanded {
+            return nil
+        }
+        return allowedLineLimit
+    }
+
+    var expansionText: String {
+        if isExpanded {
+            return "Less"
+        }
+        return "More"
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 5.0) {
+            Text(content)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineLimit(lineLimit)
+
+            Button {
+                isExpanded.toggle()
+            } label: {
+                Text(isExpanded ? "Less" : "More")
+                    .font(.caption).bold()
+                    .padding()
+                    .background(Color.primary.colorInvert())
+            }
+        }
+    }
+}
+
+// struct ExpandableTextView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ExpandableTextView()
+//    }
+// }

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/InfoView/AdditionalInfoView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/InfoView/AdditionalInfoView.swift
@@ -8,27 +8,16 @@
 import SwiftUI
 
 struct AdditionalInfoView: View {
-    @Environment(\.dismiss) var dismiss
 
     let additionalInfo: String
 
     var body: some View {
-        NavigationView {
-            Group {
-                Text(additionalInfo)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .padding()
-            .navigationTitle("Additional Notes")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done", role: .destructive) {
-                        dismiss()
-                    }
-                }
-            }
+        VStack(alignment: .leading, spacing: 10.0) {
+            Text("Additional Info")
+                .underline()
+
+            ExpandableTextView(content: additionalInfo)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/InfoView/AdditionalInfoView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/InfoView/AdditionalInfoView.swift
@@ -14,7 +14,7 @@ struct AdditionalInfoView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10.0) {
             Text("Additional Info")
-                .underline()
+                .bold()
 
             ExpandableTextView(content: additionalInfo)
                 .fixedSize(horizontal: false, vertical: true)

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/InfoView/InfoView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/InfoView/InfoView.swift
@@ -8,24 +8,15 @@
 import SwiftUI
 
 struct InfoView: View {
-    @State private var isShowingAdditionalInfoSheet = false
 
     let additionalInfo: String
 
     var body: some View {
-        HStack {
+        HStack(alignment: .top) {
             Image(systemName: "newspaper")
                 .font(.title)
 
-            Button {
-                isShowingAdditionalInfoSheet.toggle()
-            } label: {
-                Text("Additional Notes")
-            }
-            .sheet(isPresented: $isShowingAdditionalInfoSheet) {
-                AdditionalInfoView(additionalInfo: additionalInfo)
-            }
+            AdditionalInfoView(additionalInfo: additionalInfo)
         }
-
     }
 }


### PR DESCRIPTION
- Removed the `.sheet` so the Plan Diff can display the additional info
- Added an `ExpandableTextView` so if the additional info is very long, it will automatically truncate the text. You can set the line limit but default is 3 lines.
- I kept the `InfoView`, even though now it only contains an `AdditionalInfoView` in the event we want to add extra information into the view