### PR TITLE
Add filter for version in PlanLogView and option to show changes

### DIFF
--- a/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/Components/PlanDiffTextView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/Components/PlanDiffTextView.swift
@@ -20,23 +20,27 @@ struct PlanDiffTextView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: spacing) {
-            ForEach(planDiffMap.sorted(by: { $0.key > $1.key }), id: \.key) { field, change in
-                HStack(spacing: 0.0) {
-                    Text("> ").bold()
+            if planDiffMap.isEmpty {
+                Text("There are no changes between these versions")
+            } else {
+                ForEach(planDiffMap.sorted(by: { $0.key > $1.key }), id: \.key) { field, change in
+                    HStack(spacing: 0.0) {
+                        Text("> ").bold()
 
-                    Text(field).bold()
+                        Text(field).bold()
 
-                    if (change.0.count + change.1.count) < wordLimit {
-                        Text(": ").bold()
+                        if (change.0.count + change.1.count) < wordLimit {
+                            Text(": ").bold()
 
-                        Text(change.0).italic().bold()
+                            Text(change.0).italic().bold()
 
-                        Text(" -> ").bold()
+                            Text(" -> ").bold()
 
-                        Text(change.1).italic().bold()
+                            Text(change.1).italic().bold()
+                        }
                     }
+                    .opacity(0.6)
                 }
-                .opacity(0.6)
             }
         }
     }

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/Components/VersionPickerView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/Components/VersionPickerView.swift
@@ -14,16 +14,30 @@ struct VersionPickerView: View {
 
     var versionNumbers: [Int]
 
+    var labels: [Int: String]
+
     internal init(selectedVersion: Binding<Int>, onChange: @escaping (Int) -> Void, versionNumbers: [Int]) {
         self._selectedVersion = selectedVersion
         self.onVersionChange = onChange
         self.versionNumbers = versionNumbers
+        self.labels = [:]
+
+        for versionNumber in versionNumbers {
+            labels[versionNumber] = String(versionNumber)
+        }
+    }
+
+    init(selectedVersion: Binding<Int>, onChange: @escaping (Int) -> Void, versionNumbers: [Int], labels: [Int: String]) {
+        self._selectedVersion = selectedVersion
+        self.onVersionChange = onChange
+        self.versionNumbers = versionNumbers
+        self.labels = labels
     }
 
     var body: some View {
         Picker("Version", selection: $selectedVersion) {
             ForEach(versionNumbers, id: \.self) { num in
-                Text("Version: \(String(num))").tag(num)
+                Text("Version: \(self.labels[num] ?? String(num))").tag(num)
             }
         }
         .pickerStyle(.menu)

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/PlanDiffView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/PlanDiffView.swift
@@ -33,21 +33,28 @@ struct PlanDiffView<T: Plan>: View {
     }
 
     var body: some View {
-        ScrollView {
-            HStack(spacing: 5.0) {
-                SimplePlanView(planViewModel: leftViewModel,
-                               initialVersion: $leftVersion,
-                               commentsViewModel: commentsViewModel.copy(),
-                               planUpvoteViewModel: planUpvoteViewModel.copy())
+        VStack {
+            Text("Summary of changes")
+                .bold()
 
-                Divider()
-
-                SimplePlanView(planViewModel: rightViewModel,
-                               initialVersion: $rightVersion,
-                               commentsViewModel: commentsViewModel.copy(),
-                               planUpvoteViewModel: planUpvoteViewModel.copy())
-            }
             PlanDiffTextView(planDiffMap: leftViewModel.diffPlan(with: rightViewModel), spacing: 5.0)
+                .padding()
+
+            ScrollView {
+                HStack(spacing: 5.0) {
+                    SimplePlanView(planViewModel: leftViewModel,
+                                   initialVersion: $leftVersion,
+                                   commentsViewModel: commentsViewModel.copy(),
+                                   planUpvoteViewModel: planUpvoteViewModel.copy())
+
+                    Divider()
+
+                    SimplePlanView(planViewModel: rightViewModel,
+                                   initialVersion: $rightVersion,
+                                   commentsViewModel: commentsViewModel.copy(),
+                                   planUpvoteViewModel: planUpvoteViewModel.copy())
+                }
+            }
         }
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/PlanDiffView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanDiffView/PlanDiffView.swift
@@ -35,6 +35,7 @@ struct PlanDiffView<T: Plan>: View {
     var body: some View {
         VStack {
             Text("Summary of changes")
+                .font(.title2)
                 .bold()
 
             PlanDiffTextView(planDiffMap: leftViewModel.diffPlan(with: rightViewModel), spacing: 5.0)

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/PlanLogView/PlanLogListView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/PlanLogView/PlanLogListView.swift
@@ -42,8 +42,6 @@ struct PlanLogListView<T: Plan>: View {
 
                 if showChanges {
                     HStack {
-                        Image(systemName: "slider.horizontal.3")
-
                         VersionPickerView(selectedVersion: $selectedVersion,
                                           onChange: { _ in },
                                           versionNumbers: planDisplayViewModel.versionNumberChoices,

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/PlanLogView/PlanLogView.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/Components/PlanLogView/PlanLogView.swift
@@ -32,11 +32,9 @@ struct PlanLogView<T: Plan>: View {
 
     var body: some View {
         ActionableContentView { // content
-            ScrollableContentView {
-                PlanLogListView(planDisplayViewModel: planDisplayViewModel,
-                                commentsViewModel: commentsViewModel,
-                                planUpvoteViewModel: planUpvoteViewModel)
-            }
+            PlanLogListView(planDisplayViewModel: planDisplayViewModel,
+                            commentsViewModel: commentsViewModel,
+                            planUpvoteViewModel: planUpvoteViewModel)
         } actionContent: {
             if commentsViewModel.allowUserInteraction {
                 AddCommentView(viewModel: addCommentViewModel)

--- a/TourMate/TourMate/Frontend/Plan/Views/PlanViews/PlanDisplayViewModel.swift
+++ b/TourMate/TourMate/Frontend/Plan/Views/PlanViews/PlanDisplayViewModel.swift
@@ -20,6 +20,26 @@ class PlanDisplayViewModel<T: Plan>: ObservableObject {
         allVersionedPlans.sorted(by: { $0.versionNumber > $1.versionNumber })
     }
 
+    let defaultVersionNumberChoice = 0
+
+    var versionNumberChoices: [Int] {
+        var choices = [0]
+        choices.append(contentsOf: allVersionNumbers)
+        return choices
+    }
+
+    var versionLabels: [Int: String] {
+        var labels: [Int: String] = [:]
+        for choice in versionNumberChoices {
+            if choice == 0 {
+                labels[choice] = "all"
+            } else {
+                labels[choice] = String(choice)
+            }
+        }
+        return labels
+    }
+
     init(plan: T) {
         self.plan = plan
         self.allVersionedPlans = [plan]


### PR DESCRIPTION
- Add option to customise labels in VersionPickerView


For the PlanLogView, if I do not have anything to show for a Plan version (no comments), the view will still take up some space in the ScrollView. This causes weird chunks of empty spaces if I add the `Show Changes` toggle. In place of that I just use a CommentsListView to render the comments using the same view model